### PR TITLE
feat: align local projects storage structure

### DIFF
--- a/SETUP_CHECK.md
+++ b/SETUP_CHECK.md
@@ -1,0 +1,8 @@
+# Setup Check
+
+Generated: 2025-09-24T12:01:22.897Z
+
+- ✅ Bun: v1.2.14
+- ℹ️ Platform: linux (non-macOS)
+- ✅ ~/Onlook Projects: Writable at /root/Onlook Projects (checked outside macOS)
+- ✅ .env.local: Found apps/web/client/.env.local

--- a/apps/web/client/.env.example
+++ b/apps/web/client/.env.example
@@ -1,5 +1,14 @@
 # ------------- Required Keys -------------
 
+# Quickstart - optional API providers
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=
+# OPENROUTER_API_KEY=
+# CURSOR_API_KEY=
+
+# Feature flags
+# CURSOR_PLATFORM_ENABLED=false
+
 # Supabase - Enables our backend such as database and auth
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 NEXT_PUBLIC_SUPABASE_ANON_KEY="<Fill in from content after running supabase start>"

--- a/apps/web/client/package.json
+++ b/apps/web/client/package.json
@@ -24,6 +24,7 @@
         "lint:fix": "next lint --fix",
         "build": "next build",
         "start": "next start",
+        "smoke-dev": "node ../../../scripts/smoke-dev.mjs",
         "preview": "bun run build && bun run start",
         "build:standalone": "STANDALONE_BUILD=true next build && { cp -r public .next/standalone/apps/web/client/ && cp -r .next/static .next/standalone/apps/web/client/.next/; } 2>/dev/null",
         "start:standalone": "bun .next/standalone/apps/web/client/server.js",

--- a/apps/web/client/src/app/api/health/route.ts
+++ b/apps/web/client/src/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+    return NextResponse.json({ status: 'ok' });
+}

--- a/docs/ARCH-NOTES-macos.md
+++ b/docs/ARCH-NOTES-macos.md
@@ -1,0 +1,19 @@
+# Onlook Architecture Notes (macOS)
+
+## Sandbox container flow
+- Each project branch is wrapped in a `SandboxManager`, `HistoryManager`, and `ErrorManager` that the `BranchManager` wires up when branches load, ensuring every branch has an isolated sandbox session and supporting stores.【F:apps/web/client/src/components/store/editor/branch/manager.ts†L33-L71】
+- A `SandboxManager` bootstraps CodeSandbox-backed sessions through its `SessionManager`, handles indexing, and synchronizes files via its `FileSyncManager`, reacting to provider changes and file watcher events to keep the local cache consistent.【F:apps/web/client/src/components/store/editor/sandbox/index.ts†L30-L134】【F:apps/web/client/src/components/store/editor/sandbox/index.ts†L414-L516】
+- `SessionManager` connects to the hosted container through `createCodeProviderClient(CodeSandbox, …)`, initializes terminal tasks, and exposes helpers for restarting the dev task or running commands against the sandbox, giving the UI control over the remote runtime.【F:apps/web/client/src/components/store/editor/sandbox/session.ts†L1-L107】
+
+## Iframe preview and sandbox access
+- Preview frames register an `<iframe>` per branch, layering Penpal RPC helpers over the DOM element so the editor can drive zoom, reload, and other remote actions while keeping the sandbox isolated via the iframe sandbox attributes.【F:apps/web/client/src/app/project/[id]/_components/canvas/frame/view.tsx†L260-L314】
+- When a sandbox is forked or started, preview URLs are formed with `https://<sandboxId>-<port>.csb.app`, aligning the iframe source with the CodeSandbox preview host for the active branch.【F:packages/constants/src/csb.ts†L8-L23】
+
+## Code instrumentation pipeline
+- During indexing, JSX files are parsed so the `TemplateNodeManager` can inject preload scripts for root layouts, assign stable OIDs, and cache parsed template node maps, enabling design-surface overlays to map DOM nodes back to source.【F:apps/web/client/src/components/store/editor/template-nodes/index.ts†L1-L120】
+- When a tracked file is edited, the sandbox manager reprocesses it through the template node pipeline before persisting to the provider, guaranteeing that the instrumented AST stays aligned with the editor’s node map.【F:apps/web/client/src/components/store/editor/sandbox/index.ts†L271-L302】
+
+## Ports and health checks
+- Next.js development defaults to port 3000; local imports reuse that port unless a package script overrides it, so the macOS smoke test targets `http://localhost:3000` for dev URLs.【F:apps/web/client/src/app/projects/import/local/_context/index.tsx†L44-L75】
+- CodeSandbox templates also pin port 3000, matching the preview host that the editor opens when spawning new sandboxes.【F:packages/constants/src/csb.ts†L8-L23】
+- A lightweight `/api/health` route returns `{ status: 'ok' }`, giving the smoke test a stable readiness probe for the Next dev server.【F:apps/web/client/src/app/api/health/route.ts†L1-L5】

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
         "apps/web/client"
     ],
     "scripts": {
-        "dev": "cd apps/web/client && npm run dev",
-        "build": "cd apps/web/client && npm run build",
-        "start": "cd apps/web/client && npm run start",
-        "typecheck": "cd apps/web/client && npm run typecheck",
-        "lint": "cd apps/web/client && npm run lint",
+        "dev": "bun --cwd apps/web/client run dev",
+        "build": "bun --cwd apps/web/client run build",
+        "start": "bun --cwd apps/web/client run start",
+        "typecheck": "bun --cwd apps/web/client run typecheck",
+        "lint": "bun --cwd apps/web/client run lint",
+        "setup:check": "bun ./tooling/scripts/setup-check.ts",
+        "smoke-dev": "node scripts/smoke-dev.mjs",
         "prepare": "husky",
         "clean": "git clean -xdf node_modules"
     },

--- a/packages/db/src/local-storage.ts
+++ b/packages/db/src/local-storage.ts
@@ -1,6 +1,5 @@
-import { promises as fs } from 'fs';
+import { promises as fs, Dirent } from 'fs';
 import path from 'path';
-import { env } from '../../web/client/src/env';
 
 export interface LocalProject {
   id: string;
@@ -52,82 +51,278 @@ export interface LocalMessage {
 export class LocalStorage {
   private projectsDir: string;
 
-  constructor() {
-    this.projectsDir = env.ONLOOK_PROJECTS_DIR;
-    this.ensureProjectsDir();
+  private readonly ready: Promise<void>;
+
+  private readonly projectDirIndex = new Map<string, string>();
+
+  constructor(projectsDir?: string) {
+    this.projectsDir = projectsDir ?? '';
+    this.ready = this.initialize(projectsDir).catch((error) => {
+      console.error('Failed to initialize local storage directory:', error);
+      throw error;
+    });
   }
 
-  private async ensureProjectsDir() {
+  private async initialize(providedPath?: string): Promise<void> {
+    const resolvedProjectsDir =
+      providedPath ?? (await LocalStorage.resolveDefaultProjectsDir());
+
+    this.projectsDir = resolvedProjectsDir;
+
+    await fs.mkdir(this.projectsDir, { recursive: true });
+    await this.refreshProjectIndex();
+  }
+
+  private static async resolveDefaultProjectsDir(): Promise<string> {
     try {
-      await fs.mkdir(this.projectsDir, { recursive: true });
+      const { env } = await import('../../../apps/web/client/src/env');
+      return env.ONLOOK_PROJECTS_DIR;
     } catch (error) {
-      console.error('Failed to create projects directory:', error);
+      const fallback = process.env.ONLOOK_PROJECTS_DIR;
+      if (fallback && fallback.trim()) {
+        return LocalStorage.expandHomePath(fallback);
+      }
+
+      const home = process.env.HOME;
+      return home ? path.join(home, 'Onlook Projects') : './onlook-projects';
     }
   }
 
-  private getProjectPath(projectId: string): string {
-    return path.join(this.projectsDir, projectId);
+  private static expandHomePath(rawValue: string): string {
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      return trimmed;
+    }
+
+    const homeDirectory = process.env.HOME;
+    if (!homeDirectory) {
+      return trimmed;
+    }
+
+    if (trimmed === '~') {
+      return homeDirectory;
+    }
+
+    if (trimmed.startsWith('~/')) {
+      return path.join(homeDirectory, trimmed.slice(2));
+    }
+
+    if (trimmed.startsWith('$HOME')) {
+      const remainder = trimmed.slice('$HOME'.length);
+      if (!remainder) {
+        return homeDirectory;
+      }
+
+      return path.join(homeDirectory, remainder.replace(/^[/\\]/, ''));
+    }
+
+    return trimmed;
   }
 
-  private getProjectMetaPath(projectId: string): string {
-    return path.join(this.getProjectPath(projectId), 'meta.json');
+  private async ensureReady(): Promise<void> {
+    await this.ready;
   }
 
-  private getCanvasPath(projectId: string, canvasId: string): string {
-    return path.join(this.getProjectPath(projectId), 'canvases', `${canvasId}.json`);
+  private normalizeProjectName(name: string | undefined): string {
+    const fallback = 'Untitled Project';
+    if (!name) {
+      return fallback;
+    }
+
+    const trimmed = name.trim();
+    return trimmed || fallback;
   }
 
-  private getConversationPath(projectId: string, conversationId: string): string {
-    return path.join(this.getProjectPath(projectId), 'conversations', `${conversationId}.json`);
+  private toDirectoryName(name: string): string {
+    const normalized = this.normalizeProjectName(name);
+    const sanitized = normalized.replace(/[<>:"/\\|?*\x00-\x1F]/g, '-');
+    const withoutTrailing = sanitized.replace(/[. ]+$/g, '');
+    return withoutTrailing || 'Untitled Project';
   }
 
-  // Project operations
-  async createProject(project: Omit<LocalProject, 'id' | 'createdAt' | 'updatedAt'>): Promise<LocalProject> {
-    const id = this.generateId();
-    const now = new Date().toISOString();
-    const fullProject: LocalProject = {
-      ...project,
-      id,
-      createdAt: now,
-      updatedAt: now,
-    };
-
-    const projectPath = this.getProjectPath(id);
-    await fs.mkdir(projectPath, { recursive: true });
-    await fs.mkdir(path.join(projectPath, 'canvases'), { recursive: true });
-    await fs.mkdir(path.join(projectPath, 'conversations'), { recursive: true });
-    await fs.mkdir(path.join(projectPath, 'files'), { recursive: true });
-
-    await fs.writeFile(
-      this.getProjectMetaPath(id),
-      JSON.stringify(fullProject, null, 2)
-    );
-
-    return fullProject;
+  private getMetaPathFromDir(projectDir: string): string {
+    return path.join(projectDir, 'meta.json');
   }
 
-  async getProject(projectId: string): Promise<LocalProject | null> {
+  private async readProjectMeta(projectDir: string): Promise<LocalProject | null> {
     try {
-      const metaPath = this.getProjectMetaPath(projectId);
-      const data = await fs.readFile(metaPath, 'utf-8');
-      return JSON.parse(data);
+      const data = await fs.readFile(this.getMetaPathFromDir(projectDir), 'utf-8');
+      return JSON.parse(data) as LocalProject;
     } catch (error) {
       return null;
     }
   }
 
-  async updateProject(projectId: string, updates: Partial<Omit<LocalProject, 'id' | 'createdAt'>>): Promise<LocalProject | null> {
-    const project = await this.getProject(projectId);
-    if (!project) return null;
+  private async pathExists(targetPath: string): Promise<boolean> {
+    try {
+      await fs.access(targetPath);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
 
-    const updatedProject: LocalProject = {
+  private async refreshProjectIndex(): Promise<void> {
+    this.projectDirIndex.clear();
+
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(this.projectsDir, { withFileTypes: true });
+    } catch (error) {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const projectDir = path.join(this.projectsDir, entry.name);
+      const project = await this.readProjectMeta(projectDir);
+      if (project) {
+        this.projectDirIndex.set(project.id, projectDir);
+      }
+    }
+  }
+
+  private async getProjectDir(projectId: string): Promise<string | null> {
+    const existing = this.projectDirIndex.get(projectId);
+    if (existing) {
+      return existing;
+    }
+
+    await this.refreshProjectIndex();
+    return this.projectDirIndex.get(projectId) ?? null;
+  }
+
+  private async requireProjectDir(projectId: string): Promise<string> {
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      throw new Error(`Project directory not found for id ${projectId}`);
+    }
+    return projectDir;
+  }
+
+  private async ensureProjectStructure(projectDir: string): Promise<void> {
+    const directories = ['files', 'canvases', 'conversations', 'previews', 'assets'];
+    await Promise.all(
+      directories.map((directory) =>
+        fs.mkdir(path.join(projectDir, directory), { recursive: true })
+      )
+    );
+  }
+
+  private async getUniqueProjectDir(
+    baseName: string,
+    currentProjectId?: string
+  ): Promise<{ dirName: string; dirPath: string }> {
+    const targetDir = currentProjectId
+      ? await this.getProjectDir(currentProjectId)
+      : null;
+
+    let attempt = 0;
+    let candidateName = baseName;
+
+    while (true) {
+      const candidatePath = path.join(this.projectsDir, candidateName);
+      if (!(await this.pathExists(candidatePath))) {
+        return { dirName: candidateName, dirPath: candidatePath };
+      }
+
+      if (targetDir && path.resolve(candidatePath) === path.resolve(targetDir)) {
+        return { dirName: candidateName, dirPath: candidatePath };
+      }
+
+      attempt += 1;
+      candidateName = `${baseName} (${attempt})`;
+    }
+  }
+
+  // Project operations
+  async createProject(
+    project: Omit<LocalProject, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<LocalProject> {
+    await this.ensureReady();
+
+    const now = new Date().toISOString();
+    const name = this.normalizeProjectName(project.name);
+    const directoryBase = this.toDirectoryName(name);
+    const { dirPath } = await this.getUniqueProjectDir(directoryBase);
+
+    await fs.mkdir(dirPath, { recursive: true });
+    await this.ensureProjectStructure(dirPath);
+
+    const id = this.generateId();
+    const fullProject: LocalProject = {
       ...project,
-      ...updates,
-      updatedAt: new Date().toISOString(),
+      name,
+      id,
+      createdAt: now,
+      updatedAt: now,
     };
 
     await fs.writeFile(
-      this.getProjectMetaPath(projectId),
+      this.getMetaPathFromDir(dirPath),
+      JSON.stringify(fullProject, null, 2)
+    );
+
+    this.projectDirIndex.set(id, dirPath);
+
+    return fullProject;
+  }
+
+  async getProject(projectId: string): Promise<LocalProject | null> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return null;
+    }
+
+    const project = await this.readProjectMeta(projectDir);
+    if (!project) {
+      return null;
+    }
+
+    await this.ensureProjectStructure(projectDir);
+    return project;
+  }
+
+  async updateProject(
+    projectId: string,
+    updates: Partial<Omit<LocalProject, 'id' | 'createdAt'>>
+  ): Promise<LocalProject | null> {
+    await this.ensureReady();
+
+    const project = await this.getProject(projectId);
+    if (!project) {
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    const updatedProject: LocalProject = {
+      ...project,
+      ...updates,
+      name: updates.name ? this.normalizeProjectName(updates.name) : project.name,
+      updatedAt: now,
+    };
+
+    const currentDir = await this.requireProjectDir(projectId);
+    const targetDirName = this.toDirectoryName(updatedProject.name);
+    const { dirPath: targetDir } = await this.getUniqueProjectDir(
+      targetDirName,
+      projectId
+    );
+
+    if (path.resolve(currentDir) !== path.resolve(targetDir)) {
+      await fs.mkdir(path.dirname(targetDir), { recursive: true });
+      await fs.rename(currentDir, targetDir);
+      this.projectDirIndex.set(projectId, targetDir);
+    }
+
+    await this.ensureProjectStructure(targetDir);
+    await fs.writeFile(
+      this.getMetaPathFromDir(targetDir),
       JSON.stringify(updatedProject, null, 2)
     );
 
@@ -135,9 +330,16 @@ export class LocalStorage {
   }
 
   async deleteProject(projectId: string): Promise<boolean> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return false;
+    }
+
     try {
-      const projectPath = this.getProjectPath(projectId);
-      await fs.rm(projectPath, { recursive: true, force: true });
+      await fs.rm(projectDir, { recursive: true, force: true });
+      this.projectDirIndex.delete(projectId);
       return true;
     } catch (error) {
       console.error('Failed to delete project:', error);
@@ -146,28 +348,46 @@ export class LocalStorage {
   }
 
   async listProjects(): Promise<LocalProject[]> {
+    await this.ensureReady();
+
+    let entries: Dirent[];
     try {
-      const entries = await fs.readdir(this.projectsDir, { withFileTypes: true });
-      const projects: LocalProject[] = [];
-
-      for (const entry of entries) {
-        if (entry.isDirectory()) {
-          const project = await this.getProject(entry.name);
-          if (project) {
-            projects.push(project);
-          }
-        }
-      }
-
-      return projects.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      entries = await fs.readdir(this.projectsDir, { withFileTypes: true });
     } catch (error) {
       console.error('Failed to list projects:', error);
       return [];
     }
+
+    const projects: LocalProject[] = [];
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const projectDir = path.join(this.projectsDir, entry.name);
+      const project = await this.readProjectMeta(projectDir);
+      if (project) {
+        this.projectDirIndex.set(project.id, projectDir);
+        await this.ensureProjectStructure(projectDir);
+        projects.push(project);
+      }
+    }
+
+    return projects.sort(
+      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    );
   }
 
   // Canvas operations
-  async createCanvas(canvas: Omit<LocalCanvas, 'id' | 'createdAt' | 'updatedAt'>): Promise<LocalCanvas> {
+  async createCanvas(
+    canvas: Omit<LocalCanvas, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<LocalCanvas> {
+    await this.ensureReady();
+
+    const projectDir = await this.requireProjectDir(canvas.projectId);
+    await this.ensureProjectStructure(projectDir);
+
     const id = this.generateId();
     const now = new Date().toISOString();
     const fullCanvas: LocalCanvas = {
@@ -178,26 +398,47 @@ export class LocalStorage {
     };
 
     await fs.writeFile(
-      this.getCanvasPath(canvas.projectId, id),
+      path.join(projectDir, 'canvases', `${id}.json`),
       JSON.stringify(fullCanvas, null, 2)
     );
 
     return fullCanvas;
   }
 
-  async getCanvas(projectId: string, canvasId: string): Promise<LocalCanvas | null> {
+  async getCanvas(
+    projectId: string,
+    canvasId: string
+  ): Promise<LocalCanvas | null> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return null;
+    }
+
     try {
-      const canvasPath = this.getCanvasPath(projectId, canvasId);
-      const data = await fs.readFile(canvasPath, 'utf-8');
-      return JSON.parse(data);
+      const data = await fs.readFile(
+        path.join(projectDir, 'canvases', `${canvasId}.json`),
+        'utf-8'
+      );
+      return JSON.parse(data) as LocalCanvas;
     } catch (error) {
       return null;
     }
   }
 
   async listCanvases(projectId: string): Promise<LocalCanvas[]> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return [];
+    }
+
+    await this.ensureProjectStructure(projectDir);
+
     try {
-      const canvasesDir = path.join(this.getProjectPath(projectId), 'canvases');
+      const canvasesDir = path.join(projectDir, 'canvases');
       const entries = await fs.readdir(canvasesDir, { withFileTypes: true });
       const canvases: LocalCanvas[] = [];
 
@@ -211,7 +452,9 @@ export class LocalStorage {
         }
       }
 
-      return canvases.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      return canvases.sort(
+        (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      );
     } catch (error) {
       console.error('Failed to list canvases:', error);
       return [];
@@ -219,7 +462,14 @@ export class LocalStorage {
   }
 
   // Conversation operations
-  async createConversation(conversation: Omit<LocalConversation, 'id' | 'createdAt' | 'updatedAt'>): Promise<LocalConversation> {
+  async createConversation(
+    conversation: Omit<LocalConversation, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<LocalConversation> {
+    await this.ensureReady();
+
+    const projectDir = await this.requireProjectDir(conversation.projectId);
+    await this.ensureProjectStructure(projectDir);
+
     const id = this.generateId();
     const now = new Date().toISOString();
     const fullConversation: LocalConversation = {
@@ -230,26 +480,47 @@ export class LocalStorage {
     };
 
     await fs.writeFile(
-      this.getConversationPath(conversation.projectId, id),
+      path.join(projectDir, 'conversations', `${id}.json`),
       JSON.stringify(fullConversation, null, 2)
     );
 
     return fullConversation;
   }
 
-  async getConversation(projectId: string, conversationId: string): Promise<LocalConversation | null> {
+  async getConversation(
+    projectId: string,
+    conversationId: string
+  ): Promise<LocalConversation | null> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return null;
+    }
+
     try {
-      const conversationPath = this.getConversationPath(projectId, conversationId);
-      const data = await fs.readFile(conversationPath, 'utf-8');
-      return JSON.parse(data);
+      const data = await fs.readFile(
+        path.join(projectDir, 'conversations', `${conversationId}.json`),
+        'utf-8'
+      );
+      return JSON.parse(data) as LocalConversation;
     } catch (error) {
       return null;
     }
   }
 
   async listConversations(projectId: string): Promise<LocalConversation[]> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return [];
+    }
+
+    await this.ensureProjectStructure(projectDir);
+
     try {
-      const conversationsDir = path.join(this.getProjectPath(projectId), 'conversations');
+      const conversationsDir = path.join(projectDir, 'conversations');
       const entries = await fs.readdir(conversationsDir, { withFileTypes: true });
       const conversations: LocalConversation[] = [];
 
@@ -263,7 +534,9 @@ export class LocalStorage {
         }
       }
 
-      return conversations.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      return conversations.sort(
+        (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      );
     } catch (error) {
       console.error('Failed to list conversations:', error);
       return [];
@@ -271,16 +544,32 @@ export class LocalStorage {
   }
 
   // File operations
-  async saveFile(projectId: string, filePath: string, content: string): Promise<void> {
-    const fullPath = path.join(this.getProjectPath(projectId), 'files', filePath);
+  async saveFile(
+    projectId: string,
+    filePath: string,
+    content: string
+  ): Promise<void> {
+    await this.ensureReady();
+
+    const projectDir = await this.requireProjectDir(projectId);
+    await this.ensureProjectStructure(projectDir);
+
+    const fullPath = path.join(projectDir, 'files', filePath);
     const dir = path.dirname(fullPath);
     await fs.mkdir(dir, { recursive: true });
     await fs.writeFile(fullPath, content, 'utf-8');
   }
 
   async readFile(projectId: string, filePath: string): Promise<string | null> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return null;
+    }
+
     try {
-      const fullPath = path.join(this.getProjectPath(projectId), 'files', filePath);
+      const fullPath = path.join(projectDir, 'files', filePath);
       return await fs.readFile(fullPath, 'utf-8');
     } catch (error) {
       return null;
@@ -288,8 +577,17 @@ export class LocalStorage {
   }
 
   async listFiles(projectId: string, dirPath: string = ''): Promise<string[]> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return [];
+    }
+
+    await this.ensureProjectStructure(projectDir);
+
     try {
-      const fullPath = path.join(this.getProjectPath(projectId), 'files', dirPath);
+      const fullPath = path.join(projectDir, 'files', dirPath);
       const entries = await fs.readdir(fullPath, { withFileTypes: true });
       const files: string[] = [];
 

--- a/packages/db/test/local-storage.test.ts
+++ b/packages/db/test/local-storage.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { tmpdir } from 'os';
+import { LocalStorage } from '../src/local-storage';
+
+const requiredSubdirectories = [
+  'files',
+  'canvases',
+  'conversations',
+  'previews',
+  'assets',
+];
+
+const readJson = async <T>(targetPath: string): Promise<T> => {
+  const raw = await fs.readFile(targetPath, 'utf-8');
+  return JSON.parse(raw) as T;
+};
+
+describe('LocalStorage project structure', () => {
+  let baseDir: string;
+  let storage: LocalStorage;
+
+  beforeEach(async () => {
+    baseDir = await fs.mkdtemp(path.join(tmpdir(), 'onlook-local-storage-'));
+    storage = new LocalStorage(baseDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  it('creates a project tree rooted by project name', async () => {
+    const project = await storage.createProject({
+      name: 'Sample Project',
+      description: 'Example project',
+      tags: [],
+    });
+
+    const projectDir = path.join(baseDir, 'Sample Project');
+    const entries = await fs.readdir(projectDir);
+
+    expect(entries).toContain('meta.json');
+
+    for (const subdirectory of requiredSubdirectories) {
+      const stats = await fs.stat(path.join(projectDir, subdirectory));
+      expect(stats.isDirectory()).toBe(true);
+    }
+
+    const meta = await readJson<typeof project>(path.join(projectDir, 'meta.json'));
+    expect(meta.id).toBe(project.id);
+    expect(meta.name).toBe('Sample Project');
+  });
+
+  it('repairs missing project subdirectories when accessed', async () => {
+    const project = await storage.createProject({
+      name: 'Repair Project',
+      description: undefined,
+      tags: [],
+    });
+
+    const projectDir = path.join(baseDir, 'Repair Project');
+
+    await fs.rm(path.join(projectDir, 'files'), { recursive: true, force: true });
+    await fs.rm(path.join(projectDir, 'canvases'), { recursive: true, force: true });
+    await fs.rm(path.join(projectDir, 'conversations'), { recursive: true, force: true });
+
+    const fetched = await storage.getProject(project.id);
+    expect(fetched?.id).toBe(project.id);
+
+    for (const subdirectory of requiredSubdirectories) {
+      const stats = await fs.stat(path.join(projectDir, subdirectory));
+      expect(stats.isDirectory()).toBe(true);
+    }
+  });
+});

--- a/scripts/smoke-dev.mjs
+++ b/scripts/smoke-dev.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { setTimeout as delay } from 'node:timers/promises';
+import { spawn } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const clientDir = resolve(repoRoot, 'apps', 'web', 'client');
+const DEV_URL = 'http://127.0.0.1:3000';
+const HEALTH_URL = `${DEV_URL}/api/health`;
+const PAGE_URL = `${DEV_URL}/`;
+const PAGE_PATH = resolve(clientDir, 'src', 'app', 'page.tsx');
+const MARKER_TARGET = 'Welcome to Onlook';
+
+function pipeStream(stream, target) {
+    if (!stream) return;
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => target.write(chunk));
+}
+
+async function waitFor(checkFn, attempts, intervalMs) {
+    for (let i = 0; i < attempts; i += 1) {
+        if (await checkFn()) {
+            return true;
+        }
+        await delay(intervalMs);
+    }
+    return false;
+}
+
+async function waitForHealth() {
+    const ok = await waitFor(async () => {
+        try {
+            const res = await fetch(HEALTH_URL, { cache: 'no-store' });
+            return res.ok;
+        } catch (error) {
+            return false;
+        }
+    }, 60, 1000);
+
+    if (!ok) {
+        throw new Error('Timed out waiting for /api/health');
+    }
+}
+
+async function waitForMarker(marker) {
+    const ok = await waitFor(async () => {
+        try {
+            const res = await fetch(PAGE_URL, {
+                headers: {
+                    'cache-control': 'no-cache',
+                    pragma: 'no-cache',
+                },
+            });
+            if (!res.ok) {
+                return false;
+            }
+            const body = await res.text();
+            return body.includes(marker);
+        } catch (error) {
+            return false;
+        }
+    }, 60, 1000);
+
+    if (!ok) {
+        throw new Error('Hot reload did not propagate marker');
+    }
+}
+
+async function main() {
+    const devProcess = spawn('bun', ['run', 'dev'], {
+        cwd: clientDir,
+        env: {
+            ...process.env,
+            NEXT_TELEMETRY_DISABLED: '1',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let devExited = false;
+    let devExitCode = null;
+    let devExitError;
+
+    devProcess.on('exit', (code) => {
+        devExited = true;
+        devExitCode = code;
+    });
+    devProcess.on('error', (error) => {
+        devExitError = error;
+    });
+
+    pipeStream(devProcess.stdout, process.stdout);
+    pipeStream(devProcess.stderr, process.stderr);
+
+    let originalPage = '';
+    let pageModified = false;
+
+    try {
+        await waitForHealth();
+        console.log('Health check passed');
+
+        originalPage = await readFile(PAGE_PATH, 'utf8');
+        if (!originalPage.includes(MARKER_TARGET)) {
+            throw new Error(`Unable to find marker target "${MARKER_TARGET}" in page.tsx`);
+        }
+
+        const marker = `hot reload marker ${Date.now()}`;
+        const updatedPage = originalPage.replace(MARKER_TARGET, `${MARKER_TARGET} ${marker}`);
+
+        if (updatedPage === originalPage) {
+            throw new Error('Failed to apply marker update to page.tsx');
+        }
+
+        await writeFile(PAGE_PATH, updatedPage, 'utf8');
+        pageModified = true;
+
+        await waitForMarker(marker);
+        console.log('hot reload active');
+        console.log('Smoke test complete');
+    } finally {
+        if (pageModified) {
+            await writeFile(PAGE_PATH, originalPage, 'utf8');
+        }
+
+        if (!devExited) {
+            devProcess.kill('SIGTERM');
+            await new Promise((resolve) => {
+                devProcess.once('exit', resolve);
+            });
+        }
+
+        if (devExitError) {
+            throw devExitError;
+        }
+
+        if (devExitCode !== 0 && devExitCode !== null) {
+            throw new Error(`Dev server exited with code ${devExitCode}`);
+        }
+    }
+}
+
+main().catch((error) => {
+    console.error(error instanceof Error ? error.stack ?? error.message : error);
+    process.exitCode = 1;
+});

--- a/tooling/scripts/setup-check.ts
+++ b/tooling/scripts/setup-check.ts
@@ -1,0 +1,108 @@
+import { promises as fs, constants as fsConstants } from "fs";
+import os from "os";
+import path from "path";
+
+const statusSymbols = {
+    pass: "✅",
+    fail: "❌",
+    info: "ℹ️"
+} as const;
+
+type Status = keyof typeof statusSymbols;
+
+type CheckResult = {
+    label: string;
+    status: Status;
+    note: string;
+};
+
+const results: CheckResult[] = [];
+
+const bunVersion = Bun.version;
+results.push({
+    label: "Bun",
+    status: "pass",
+    note: `v${bunVersion}`
+});
+
+const platform = process.platform;
+const isMac = platform === "darwin";
+results.push({
+    label: "Platform",
+    status: "info",
+    note: isMac ? "macOS" : `${platform} (non-macOS)`
+});
+
+const homeDirectory = os.homedir();
+const projectsDirName = "Onlook Projects";
+const projectsDir = path.join(homeDirectory, projectsDirName);
+
+let projectsStatus: Status = "pass";
+let projectsNote = "";
+
+try {
+    await fs.mkdir(projectsDir, { recursive: true });
+    await fs.access(projectsDir, fsConstants.W_OK);
+    projectsNote = `Writable at ${projectsDir}${isMac ? "" : " (checked outside macOS)"}`;
+} catch (error) {
+    projectsStatus = "fail";
+    const message = error instanceof Error ? error.message : String(error);
+    projectsNote = `Failed to verify access at ${projectsDir}: ${message}`;
+}
+
+results.push({
+    label: "~/Onlook Projects",
+    status: projectsStatus,
+    note: projectsNote
+});
+
+const envLocalRelativePath = path.join("apps", "web", "client", ".env.local");
+const envLocalPath = path.join(process.cwd(), envLocalRelativePath);
+const envLocalContents = [
+    "NODE_ENV=development",
+    "NEXT_PUBLIC_SITE_URL=http://localhost:3000",
+    "ONLOOK_PROJECTS_DIR=\"$HOME/Onlook Projects\"",
+    ""
+].join("\n");
+
+let envLocalStatus: Status = "pass";
+let envLocalNote = "";
+
+try {
+    await fs.access(envLocalPath, fsConstants.F_OK);
+    envLocalNote = `Found ${envLocalRelativePath}`;
+} catch {
+    try {
+        await fs.writeFile(envLocalPath, envLocalContents, { flag: "wx" });
+        envLocalNote = `Created ${envLocalRelativePath}`;
+    } catch (error) {
+        envLocalStatus = "fail";
+        const message = error instanceof Error ? error.message : String(error);
+        envLocalNote = `Unable to create ${envLocalRelativePath}: ${message}`;
+    }
+}
+
+results.push({
+    label: ".env.local",
+    status: envLocalStatus,
+    note: envLocalNote
+});
+
+const lines: string[] = [
+    "# Setup Check",
+    "",
+    `Generated: ${new Date().toISOString()}`,
+    "",
+    ...results.map(({ label, status, note }) => `- ${statusSymbols[status]} ${label}: ${note}`),
+    ""
+];
+
+await fs.writeFile("SETUP_CHECK.md", lines.join("\n"), "utf8");
+
+for (const { label, status, note } of results) {
+    console.log(`${statusSymbols[status]} ${label}: ${note}`);
+}
+
+if (results.some(({ status }) => status === "fail")) {
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary
- update the local storage layer to resolve project folders under the configured ONLOOK_PROJECTS_DIR, ensure required subdirectories exist, and lazily load the default path
- create a Bun test suite that verifies the project tree is created from the project name and that missing directories are restored when accessed

## Testing
- bun test packages/db/test/local-storage.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d3dae000f8832c86153a1e5095ff13