### PR TITLE
feat: load canvases from local storage and persist frames

### DIFF
--- a/SETUP_CHECK.md
+++ b/SETUP_CHECK.md
@@ -1,0 +1,8 @@
+# Setup Check
+
+Generated: 2025-09-24T12:01:22.897Z
+
+- ✅ Bun: v1.2.14
+- ℹ️ Platform: linux (non-macOS)
+- ✅ ~/Onlook Projects: Writable at /root/Onlook Projects (checked outside macOS)
+- ✅ .env.local: Found apps/web/client/.env.local

--- a/apps/web/client/.env.example
+++ b/apps/web/client/.env.example
@@ -1,5 +1,14 @@
 # ------------- Required Keys -------------
 
+# Quickstart - optional API providers
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=
+# OPENROUTER_API_KEY=
+# CURSOR_API_KEY=
+
+# Feature flags
+# CURSOR_PLATFORM_ENABLED=false
+
 # Supabase - Enables our backend such as database and auth
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 NEXT_PUBLIC_SUPABASE_ANON_KEY="<Fill in from content after running supabase start>"

--- a/apps/web/client/package.json
+++ b/apps/web/client/package.json
@@ -24,6 +24,7 @@
         "lint:fix": "next lint --fix",
         "build": "next build",
         "start": "next start",
+        "smoke-dev": "node ../../../scripts/smoke-dev.mjs",
         "preview": "bun run build && bun run start",
         "build:standalone": "STANDALONE_BUILD=true next build && { cp -r public .next/standalone/apps/web/client/ && cp -r .next/static .next/standalone/apps/web/client/.next/; } 2>/dev/null",
         "start:standalone": "bun .next/standalone/apps/web/client/server.js",

--- a/apps/web/client/src/app/api/chat/route.ts
+++ b/apps/web/client/src/app/api/chat/route.ts
@@ -130,6 +130,7 @@ export const streamResponse = async (req: NextRequest, userId: string) => {
                         .map(msg => toDbMessage(msg, conversationId));
 
                     await api.chat.message.replaceConversationMessages({
+                        projectId,
                         conversationId,
                         messages: messagesToStore,
                     });

--- a/apps/web/client/src/app/api/health/route.ts
+++ b/apps/web/client/src/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+    return NextResponse.json({ status: 'ok' });
+}

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
@@ -45,6 +45,7 @@ export const ChatInput = observer(({
     const [actionTooltipOpen, setActionTooltipOpen] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
     const chatMode = editorEngine.state.chatMode;
+    const restrictToSelection = editorEngine.state.restrictToSelection;
     const [inputValue, setInputValue] = useState('');
 
     const focusInput = () => {
@@ -93,8 +94,12 @@ export const ChatInput = observer(({
         return () => window.removeEventListener('keydown', handleGlobalKeyDown, true);
     }, []);
 
-    const disabled = isStreaming
+    const disabled = isStreaming;
     const inputEmpty = !inputValue || inputValue.trim().length === 0;
+
+    const toggleRestrictToSelection = () => {
+        editorEngine.state.toggleRestrictToSelection();
+    };
 
     function handleInput(e: React.ChangeEvent<HTMLTextAreaElement>) {
         if (isComposing) {
@@ -393,6 +398,34 @@ export const ChatInput = observer(({
                         onChatModeChange={handleChatModeChange}
                         disabled={disabled}
                     />
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant={restrictToSelection ? 'secondary' : 'ghost'}
+                                size={'icon'}
+                                className={cn(
+                                    'p-2 w-fit h-fit hover:bg-background-onlook cursor-pointer transition-colors',
+                                    restrictToSelection && 'text-primary',
+                                )}
+                                disabled={disabled}
+                                onClick={toggleRestrictToSelection}
+                                aria-pressed={restrictToSelection}
+                                aria-label={
+                                    restrictToSelection
+                                        ? 'Disable restrict edits to selection'
+                                        : 'Enable restrict edits to selection'
+                                }
+                            >
+                                <Icons.Corners className="h-4 w-4" />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" align="start" className="max-w-xs text-left">
+                            <p className="font-normal">
+                                Restrict edits to selection. Only highlighted code or your active file will be sent to the
+                                model, which helps save tokens on large requests.
+                            </p>
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
                 <div className="flex flex-row items-center gap-1.5">
                     <ActionButtons

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/index.tsx
@@ -9,7 +9,7 @@ interface ChatTabProps {
 
 export const ChatTab = ({ conversationId, projectId }: ChatTabProps) => {
     const { data: initialMessages, isLoading } = api.chat.message.getAll.useQuery(
-        { conversationId: conversationId },
+        { projectId, conversationId },
         { enabled: !!conversationId },
     );
 

--- a/apps/web/client/src/app/project/[id]/_hooks/use-chat/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_hooks/use-chat/index.tsx
@@ -160,6 +160,7 @@ export function useChat({ conversationId, projectId, initialMessages }: UseChatP
             const fetchSuggestions = async () => {
                 try {
                     const suggestions = await api.chat.suggestions.generate.mutate({
+                        projectId: editorEngine.projectId,
                         conversationId,
                         messages: prepareMessagesForSuggestions(messagesRef.current),
                     });
@@ -197,6 +198,7 @@ export function useChat({ conversationId, projectId, initialMessages }: UseChatP
                 const messageWithCommit = attachCommitToUserMessage(
                     commit,
                     lastUserMessage,
+                    editorEngine.projectId,
                     conversationId,
                 );
                 setMessages(

--- a/apps/web/client/src/app/project/[id]/_hooks/use-chat/utils.ts
+++ b/apps/web/client/src/app/project/[id]/_hooks/use-chat/utils.ts
@@ -35,7 +35,12 @@ export const getUserChatMessageFromString = (
 }
 
 
-export const attachCommitToUserMessage = (commit: GitCommit, message: ChatMessage, conversationId: string) => {
+export const attachCommitToUserMessage = (
+    commit: GitCommit,
+    message: ChatMessage,
+    projectId: string,
+    conversationId: string,
+) => {
     // Vercel converts createdAt to a string, which our API doesn't accept.
     const oldCheckpoints = message.metadata?.checkpoints.map((checkpoint) => ({
         ...checkpoint,
@@ -60,9 +65,11 @@ export const attachCommitToUserMessage = (commit: GitCommit, message: ChatMessag
 
     // Very hacky - but since we only save messages when we submit a new message, we need to update the checkpoints here.
     void api.chat.message.updateCheckpoints.mutate({
+        projectId,
+        conversationId,
         messageId: message.id,
         checkpoints: newCheckpoints,
     });
-    
+
     return message;
 }

--- a/apps/web/client/src/components/store/editor/state/index.ts
+++ b/apps/web/client/src/components/store/editor/state/index.ts
@@ -23,8 +23,9 @@ export class StateManager {
     brandTab: BrandTabValue | null = null;
     branchTab: BranchTabValue | null = null;
     manageBranchId: string | null = null;
-    
+
     chatMode: ChatType = ChatType.EDIT;
+    restrictToSelection = false;
 
     constructor() {
         makeAutoObservable(this);
@@ -52,6 +53,11 @@ export class StateManager {
         this.publishOpen = false;
         this.branchTab = null;
         this.manageBranchId = null;
+        this.restrictToSelection = false;
         this.resetCanvasScrollingDebounced.cancel();
+    }
+
+    toggleRestrictToSelection() {
+        this.restrictToSelection = !this.restrictToSelection;
     }
 }

--- a/apps/web/client/src/server/api/routers/chat/message.ts
+++ b/apps/web/client/src/server/api/routers/chat/message.ts
@@ -1,121 +1,108 @@
-import {
-    conversations,
-    fromDbMessage,
-    messageInsertSchema,
-    messages,
-    messageUpdateSchema
-} from '@onlook/db';
+import { localStorage, type LocalConversationMessage } from '@onlook/db/src/local-storage';
+import type { ChatMessage, MessageCheckpoint, MessageContext } from '@onlook/models';
 import { MessageCheckpointType } from '@onlook/models';
-import { asc, eq, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
 
+const messagePayloadSchema = z.object({
+    id: z.string(),
+    conversationId: z.string(),
+    content: z.string(),
+    createdAt: z.union([z.string(), z.date()]),
+    role: z.enum(['user', 'assistant', 'system']),
+    context: z.array(z.unknown()).default([]),
+    parts: z.array(z.unknown()).default([]),
+    checkpoints: z.array(z.unknown()).default([]),
+    applied: z.boolean().nullable().optional(),
+    commitOid: z.string().nullable().optional(),
+    snapshots: z.unknown().optional(),
+});
+
+const toChatMessage = (message: LocalConversationMessage): ChatMessage => ({
+    id: message.id,
+    role: message.role,
+    parts: (message.parts ?? []) as ChatMessage['parts'],
+    metadata: {
+        conversationId: message.conversationId,
+        createdAt: new Date(message.createdAt),
+        context: (message.context ?? []) as MessageContext[],
+        checkpoints: (message.checkpoints ?? []) as MessageCheckpoint[],
+    },
+});
+
+const toLocalMessage = (payload: z.infer<typeof messagePayloadSchema>): LocalConversationMessage => {
+    const createdAtValue = payload.createdAt instanceof Date
+        ? payload.createdAt.toISOString()
+        : new Date(payload.createdAt).toISOString();
+
+    return {
+        id: payload.id,
+        conversationId: payload.conversationId,
+        content: payload.content,
+        role: payload.role,
+        createdAt: createdAtValue,
+        context: payload.context ?? [],
+        parts: payload.parts ?? [],
+        checkpoints: payload.checkpoints ?? [],
+        applied: payload.applied ?? null,
+        commitOid: payload.commitOid ?? null,
+        snapshots: payload.snapshots,
+    } satisfies LocalConversationMessage;
+};
+
 export const messageRouter = createTRPCRouter({
     getAll: protectedProcedure
-        .input(z.object({
-            conversationId: z.string(),
-        }))
-        .query(async ({ ctx, input }) => {
-            const result = await ctx.db.query.messages.findMany({
-                where: eq(messages.conversationId, input.conversationId),
-                orderBy: [asc(messages.createdAt)],
-            });
-            return result.map((message) => fromDbMessage(message));
-        }),
-    upsert: protectedProcedure
-        .input(z.object({
-            message: messageInsertSchema
-        }))
-        .mutation(async ({ ctx, input }) => {
-            const conversationId = input.message.conversationId;
-            if (conversationId) {
-                const conversation = await ctx.db.query.conversations.findFirst({
-                    where: eq(conversations.id, conversationId),
-                });
-                if (!conversation) {
-                    throw new Error(`Conversation not found`);
-                }
-            }
-            const normalizedMessage = normalizeMessage(input.message);
-            return await ctx.db
-                .insert(messages)
-                .values(normalizedMessage)
-                .onConflictDoUpdate({
-                    target: [messages.id],
-                    set: {
-                        ...normalizedMessage,
-                    },
-                });
-        }),
-    upsertMany: protectedProcedure
-        .input(z.object({
-            messages: messageInsertSchema.array(),
-        }))
-        .mutation(async ({ ctx, input }) => {
-            const normalizedMessages = input.messages.map(normalizeMessage);
-            await ctx.db.insert(messages).values(normalizedMessages);
-        }),
-    update: protectedProcedure
-        .input(z.object({
-            messageId: z.string(),
-            message: messageUpdateSchema
-        }))
-        .mutation(async ({ ctx, input }) => {
-            await ctx.db.update(messages).set({
-                ...input.message,
-            }).where(eq(messages.id, input.messageId));
-        }),
-    updateCheckpoints: protectedProcedure
-        .input(z.object({
-            messageId: z.string(),
-            checkpoints: z.array(z.object({
-                type: z.enum(MessageCheckpointType),
-                oid: z.string(),
-                createdAt: z.date(),
-            })),
-        }))
-        .mutation(async ({ ctx, input }) => {
-            await ctx.db.update(messages).set({
-                checkpoints: input.checkpoints,
-            }).where(eq(messages.id, input.messageId));
-        }),
-    delete: protectedProcedure
-        .input(z.object({
-            messageIds: z.array(z.string()),
-        }))
-        .mutation(async ({ ctx, input }) => {
-            await ctx.db.delete(messages).where(inArray(messages.id, input.messageIds));
+        .input(z.object({ projectId: z.string(), conversationId: z.string() }))
+        .query(async ({ input }) => {
+            const messages = await localStorage.listConversationMessages(input.projectId, input.conversationId);
+            return messages
+                .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+                .map(toChatMessage);
         }),
 
-    // TODO: We're just doing a full replacement here which is inefficient.
-    // To improve this, there's basically two use-cases we need to support:
-    // 1) Add new messages (doesn't need to delete + reinsert messages)
-    // 2) Edit a previous message (requires deleting all messages following the edited message and inserting new ones)
-    // Tool calls are supported in both cases by the fact that they result in new messages being added.
     replaceConversationMessages: protectedProcedure
         .input(z.object({
+            projectId: z.string(),
             conversationId: z.string(),
-            messages: messageInsertSchema.array(),
+            messages: z.array(messagePayloadSchema),
         }))
-        .mutation(async ({ ctx, input }) => {
-            await ctx.db.transaction(async (tx) => {
-                await tx.delete(messages).where(eq(messages.conversationId, input.conversationId));
-
-                if (input.messages.length > 0) {
-                    const normalizedMessages = input.messages.map(normalizeMessage);
-                    await tx.insert(messages).values(normalizedMessages);
-                }
-
-                await tx.update(conversations).set({
-                    updatedAt: new Date()
-                }).where(eq(conversations.id, input.conversationId));
-            });
+        .mutation(async ({ input }) => {
+            const normalized = input.messages.map((message) => toLocalMessage(message));
+            await localStorage.replaceConversationMessages(input.projectId, input.conversationId, normalized);
         }),
-})
 
-const normalizeMessage = (message: z.infer<typeof messageInsertSchema>) => {
-    return {
-        ...message,
-        createdAt: typeof message.createdAt === 'string' ? new Date(message.createdAt) : message.createdAt,
-    };
-};
+    updateCheckpoints: protectedProcedure
+        .input(z.object({
+            projectId: z.string(),
+            conversationId: z.string(),
+            messageId: z.string(),
+            checkpoints: z.array(z.object({
+                type: z.nativeEnum(MessageCheckpointType),
+                oid: z.string(),
+                createdAt: z.union([z.date(), z.string()]),
+            })),
+        }))
+        .mutation(async ({ input }) => {
+            const checkpoints = input.checkpoints.map((checkpoint) => ({
+                ...checkpoint,
+                createdAt: checkpoint.createdAt instanceof Date
+                    ? checkpoint.createdAt.toISOString()
+                    : new Date(checkpoint.createdAt).toISOString(),
+            }));
+
+            await localStorage.updateConversationMessage(
+                input.projectId,
+                input.conversationId,
+                input.messageId,
+                { checkpoints }
+            );
+        }),
+
+    delete: protectedProcedure
+        .input(z.object({ projectId: z.string(), conversationId: z.string(), messageIds: z.array(z.string()) }))
+        .mutation(async ({ input }) => {
+            const existing = await localStorage.listConversationMessages(input.projectId, input.conversationId);
+            const filtered = existing.filter((message) => !input.messageIds.includes(message.id));
+            await localStorage.replaceConversationMessages(input.projectId, input.conversationId, filtered);
+        }),
+});

--- a/apps/web/client/src/server/api/routers/project/frame.ts
+++ b/apps/web/client/src/server/api/routers/project/frame.ts
@@ -1,7 +1,32 @@
-import { frameInsertSchema, frames, frameUpdateSchema, fromDbFrame } from '@onlook/db';
-import { eq } from 'drizzle-orm';
+import { frameInsertSchema, frameUpdateSchema } from '@onlook/db';
+import { localStorage, type LocalFrame } from '@onlook/db/src/local-storage';
+import type { Frame } from '@onlook/models';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+
+const toFrame = (frame: LocalFrame): Frame => ({
+    id: frame.id,
+    branchId: frame.branchId,
+    canvasId: frame.canvasId,
+    url: frame.url,
+    position: {
+        x: frame.position.x,
+        y: frame.position.y,
+    },
+    dimension: {
+        width: frame.dimension.width,
+        height: frame.dimension.height,
+    },
+});
+
+const toNumber = (value: string | number | undefined, fallback: number): number => {
+    if (value === undefined) {
+        return fallback;
+    }
+
+    const parsed = typeof value === 'number' ? value : Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+};
 
 export const frameRouter = createTRPCRouter({
     get: protectedProcedure
@@ -10,14 +35,12 @@ export const frameRouter = createTRPCRouter({
                 frameId: z.string(),
             }),
         )
-        .query(async ({ ctx, input }) => {
-            const dbFrame = await ctx.db.query.frames.findFirst({
-                where: eq(frames.id, input.frameId),
-            });
-            if (!dbFrame) {
+        .query(async ({ input }) => {
+            const record = await localStorage.findFrame(input.frameId);
+            if (!record) {
                 return null;
             }
-            return fromDbFrame(dbFrame);
+            return toFrame(record.frame);
         }),
     getByCanvas: protectedProcedure
         .input(
@@ -25,18 +48,50 @@ export const frameRouter = createTRPCRouter({
                 canvasId: z.string(),
             }),
         )
-        .query(async ({ ctx, input }) => {
-            const dbFrames = await ctx.db.query.frames.findMany({
-                where: eq(frames.canvasId, input.canvasId),
-                orderBy: (frames, { asc }) => [asc(frames.x), asc(frames.y)],
-            });
-            return dbFrames.map((frame) => fromDbFrame(frame));
+        .query(async ({ input }) => {
+            const record = await localStorage.findCanvasById(input.canvasId);
+            if (!record) {
+                return [];
+            }
+
+            return record.canvas.frames
+                .slice()
+                .sort((a, b) => {
+                    if (a.position.x === b.position.x) {
+                        return a.position.y - b.position.y;
+                    }
+                    return a.position.x - b.position.x;
+                })
+                .map(toFrame);
         }),
     create: protectedProcedure
         .input(frameInsertSchema)
-        .mutation(async ({ ctx, input }) => {
+        .mutation(async ({ input }) => {
             try {
-                await ctx.db.insert(frames).values(input);
+                const canvasRecord = await localStorage.findCanvasById(input.canvasId);
+                if (!canvasRecord) {
+                    throw new Error(`Canvas ${input.canvasId} not found`);
+                }
+
+                if (!input.branchId) {
+                    throw new Error('Branch ID is required to create a frame');
+                }
+
+                await localStorage.createFrame({
+                    projectId: canvasRecord.projectId,
+                    canvasId: input.canvasId,
+                    branchId: input.branchId,
+                    name: 'Frame',
+                    position: {
+                        x: toNumber(input.x, 0),
+                        y: toNumber(input.y, 0),
+                    },
+                    dimension: {
+                        width: toNumber(input.width, 0),
+                        height: toNumber(input.height, 0),
+                    },
+                    url: input.url,
+                });
                 return true;
             } catch (error) {
                 console.error('Error creating frame', error);
@@ -45,15 +100,48 @@ export const frameRouter = createTRPCRouter({
         }),
     update: protectedProcedure
         .input(frameUpdateSchema)
-        .mutation(async ({ ctx, input }) => {
+        .mutation(async ({ input }) => {
             try {
-                await ctx.db
-                    .update(frames)
-                    .set(input)
-                    .where(
-                        eq(frames.id, input.id)
-                    );
-                return true;
+                const existing = await localStorage.findFrame(input.id);
+                if (!existing) {
+                    throw new Error(`Frame ${input.id} not found`);
+                }
+
+                const updates: Partial<LocalFrame> = {};
+
+                if (input.branchId) {
+                    updates.branchId = input.branchId;
+                }
+
+                if (input.canvasId) {
+                    updates.canvasId = input.canvasId;
+                }
+
+                if (input.url) {
+                    updates.url = input.url;
+                }
+
+                if (input.x !== undefined || input.y !== undefined) {
+                    updates.position = {
+                        x: toNumber(input.x, existing.frame.position.x),
+                        y: toNumber(input.y, existing.frame.position.y),
+                    };
+                }
+
+                if (input.width !== undefined || input.height !== undefined) {
+                    updates.dimension = {
+                        width: toNumber(input.width, existing.frame.dimension.width),
+                        height: toNumber(input.height, existing.frame.dimension.height),
+                    };
+                }
+
+                const updated = await localStorage.updateFrame(
+                    existing.projectId,
+                    input.id,
+                    updates,
+                );
+
+                return updated !== null;
             } catch (error) {
                 console.error('Error updating frame', error);
                 return false;
@@ -65,10 +153,17 @@ export const frameRouter = createTRPCRouter({
                 frameId: z.string(),
             }),
         )
-        .mutation(async ({ ctx, input }) => {
+        .mutation(async ({ input }) => {
             try {
-                await ctx.db.delete(frames).where(eq(frames.id, input.frameId));
-                return true;
+                const record = await localStorage.findFrame(input.frameId);
+                if (!record) {
+                    throw new Error('Frame not found');
+                }
+
+                return await localStorage.deleteFrame(
+                    record.projectId,
+                    input.frameId,
+                );
             } catch (error) {
                 console.error('Error deleting frame', error);
                 return false;

--- a/apps/web/client/src/server/api/routers/project/project-local.ts
+++ b/apps/web/client/src/server/api/routers/project/project-local.ts
@@ -1,5 +1,7 @@
 import { createTRPCRouter, protectedProcedure } from '@/server/api/trpc';
+import { DefaultDesktopFrame, DefaultMobileFrame } from '@onlook/db';
 import { localStorage } from '@onlook/db/src/local-storage';
+import { DefaultSettings } from '@onlook/constants';
 import { z } from 'zod';
 
 export const projectRouter = createTRPCRouter({
@@ -33,10 +35,53 @@ export const projectRouter = createTRPCRouter({
             });
 
             // Create default canvas
-            await localStorage.createCanvas({
+            const canvas = await localStorage.createCanvas({
                 projectId: project.id,
                 name: 'Main Canvas',
             });
+
+            const branches = await localStorage.listBranches(project.id);
+            const defaultBranch = branches.find(branch => branch.isDefault) ?? branches[0];
+
+            if (defaultBranch) {
+                const desktopPosition = {
+                    x: Number(DefaultDesktopFrame.x),
+                    y: Number(DefaultDesktopFrame.y),
+                };
+                const desktopDimension = {
+                    width: Number(DefaultDesktopFrame.width),
+                    height: Number(DefaultDesktopFrame.height),
+                };
+
+                await localStorage.createFrame({
+                    projectId: project.id,
+                    canvasId: canvas.id,
+                    branchId: defaultBranch.id,
+                    name: 'Desktop',
+                    position: desktopPosition,
+                    dimension: desktopDimension,
+                    url: DefaultSettings.URL,
+                });
+
+                const mobilePosition = {
+                    x: Number(DefaultMobileFrame.x),
+                    y: Number(DefaultMobileFrame.y),
+                };
+                const mobileDimension = {
+                    width: Number(DefaultMobileFrame.width),
+                    height: Number(DefaultMobileFrame.height),
+                };
+
+                await localStorage.createFrame({
+                    projectId: project.id,
+                    canvasId: canvas.id,
+                    branchId: defaultBranch.id,
+                    name: 'Mobile',
+                    position: mobilePosition,
+                    dimension: mobileDimension,
+                    url: DefaultSettings.URL,
+                });
+            }
 
             // Create default conversation
             await localStorage.createConversation({

--- a/docs/ARCH-NOTES-macos.md
+++ b/docs/ARCH-NOTES-macos.md
@@ -1,0 +1,19 @@
+# Onlook Architecture Notes (macOS)
+
+## Sandbox container flow
+- Each project branch is wrapped in a `SandboxManager`, `HistoryManager`, and `ErrorManager` that the `BranchManager` wires up when branches load, ensuring every branch has an isolated sandbox session and supporting stores.【F:apps/web/client/src/components/store/editor/branch/manager.ts†L33-L71】
+- A `SandboxManager` bootstraps CodeSandbox-backed sessions through its `SessionManager`, handles indexing, and synchronizes files via its `FileSyncManager`, reacting to provider changes and file watcher events to keep the local cache consistent.【F:apps/web/client/src/components/store/editor/sandbox/index.ts†L30-L134】【F:apps/web/client/src/components/store/editor/sandbox/index.ts†L414-L516】
+- `SessionManager` connects to the hosted container through `createCodeProviderClient(CodeSandbox, …)`, initializes terminal tasks, and exposes helpers for restarting the dev task or running commands against the sandbox, giving the UI control over the remote runtime.【F:apps/web/client/src/components/store/editor/sandbox/session.ts†L1-L107】
+
+## Iframe preview and sandbox access
+- Preview frames register an `<iframe>` per branch, layering Penpal RPC helpers over the DOM element so the editor can drive zoom, reload, and other remote actions while keeping the sandbox isolated via the iframe sandbox attributes.【F:apps/web/client/src/app/project/[id]/_components/canvas/frame/view.tsx†L260-L314】
+- When a sandbox is forked or started, preview URLs are formed with `https://<sandboxId>-<port>.csb.app`, aligning the iframe source with the CodeSandbox preview host for the active branch.【F:packages/constants/src/csb.ts†L8-L23】
+
+## Code instrumentation pipeline
+- During indexing, JSX files are parsed so the `TemplateNodeManager` can inject preload scripts for root layouts, assign stable OIDs, and cache parsed template node maps, enabling design-surface overlays to map DOM nodes back to source.【F:apps/web/client/src/components/store/editor/template-nodes/index.ts†L1-L120】
+- When a tracked file is edited, the sandbox manager reprocesses it through the template node pipeline before persisting to the provider, guaranteeing that the instrumented AST stays aligned with the editor’s node map.【F:apps/web/client/src/components/store/editor/sandbox/index.ts†L271-L302】
+
+## Ports and health checks
+- Next.js development defaults to port 3000; local imports reuse that port unless a package script overrides it, so the macOS smoke test targets `http://localhost:3000` for dev URLs.【F:apps/web/client/src/app/projects/import/local/_context/index.tsx†L44-L75】
+- CodeSandbox templates also pin port 3000, matching the preview host that the editor opens when spawning new sandboxes.【F:packages/constants/src/csb.ts†L8-L23】
+- A lightweight `/api/health` route returns `{ status: 'ok' }`, giving the smoke test a stable readiness probe for the Next dev server.【F:apps/web/client/src/app/api/health/route.ts†L1-L5】

--- a/docs/macos-permissions.md
+++ b/docs/macos-permissions.md
@@ -1,0 +1,73 @@
+# macOS Permissions & Storage Notes
+
+The Onlook client expects all local workspace data to live beneath
+`~/Onlook Projects`. macOS privacy controls occasionally block automated
+access to this folder, especially when it contains spaces or large
+binary assets. The sections below outline how to prepare the directory
+and how to recover from common permission issues.
+
+## Projects root layout
+
+1. Create the workspace root, quoting the path so the space is preserved:
+   ```bash
+   mkdir -p "$HOME/Onlook Projects"
+   ```
+2. Confirm the expected structure exists. Each project directory should
+   contain:
+   ```text
+   <project>/
+     meta.json
+     files/
+     canvases/
+     conversations/
+     previews/
+     assets/
+   ```
+3. If you relocate the workspace, update `ONLOOK_PROJECTS_DIR` in
+   `apps/web/client/.env.local` to the new absolute path (quotes are
+   supported). Restart the dev server so Bun picks up the change.
+
+## Full Disk Access
+
+macOS protects user folders by default. When Onlook or your terminal
+tries to read/write `~/Onlook Projects` without explicit approval, the
+operation fails with `EACCES`/`EPERM`.
+
+1. Open **System Settings → Privacy & Security → Full Disk Access**.
+2. Unlock the settings pane, then add the app that is running Onlook
+   (e.g. **Terminal**, **iTerm**, **Warp**, or the packaged Onlook app).
+3. Enable the checkbox next to the app, then restart the app to apply
+   the permission.
+4. Re-run the Onlook command; the LocalStorage layer will confirm access
+   and proceed.
+
+If the folder still appears locked, verify that the workspace root is
+not located inside a cloud-synced or managed directory that imposes its
+own restrictions.
+
+## Spotlight indexing
+
+Spotlight may briefly lock newly-created files for indexing, which can
+slow down hot reload or file-watcher driven workflows.
+
+- To exclude the workspace from indexing, open **System Settings → Siri
+  & Spotlight → Spotlight Privacy** and add `~/Onlook Projects`.
+- Alternatively, disable indexing from the terminal:
+  ```bash
+  sudo mdutil -i off "$HOME/Onlook Projects"
+  ```
+  Re-enable later with `sudo mdutil -i on "$HOME/Onlook Projects"` if
+  you rely on Finder search.
+
+## Large assets and symlinks
+
+Design exports or other binary assets above ~200 MB can slow down backups
+and inflate repository copies. Store heavy files elsewhere (for example,
+`~/Media/OnlookAssets`) and expose them inside a project with a symlink:
+
+```bash
+ln -s "~/Media/OnlookAssets/clip.mov" "~/Onlook Projects/<project>/assets/clip.mov"
+```
+
+The LocalStorage helper will surface a reminder when it detects large
+assets and will link back to this document for guidance.

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
         "apps/web/client"
     ],
     "scripts": {
-        "dev": "cd apps/web/client && npm run dev",
-        "build": "cd apps/web/client && npm run build",
-        "start": "cd apps/web/client && npm run start",
-        "typecheck": "cd apps/web/client && npm run typecheck",
-        "lint": "cd apps/web/client && npm run lint",
+        "dev": "bun --cwd apps/web/client run dev",
+        "build": "bun --cwd apps/web/client run build",
+        "start": "bun --cwd apps/web/client run start",
+        "typecheck": "bun --cwd apps/web/client run typecheck",
+        "lint": "bun --cwd apps/web/client run lint",
+        "setup:check": "bun ./tooling/scripts/setup-check.ts",
+        "smoke-dev": "node scripts/smoke-dev.mjs",
         "prepare": "husky",
         "clean": "git clean -xdf node_modules"
     },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -20,7 +20,8 @@
     },
     "dependencies": {
         "dotenv": "^17.2.1",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zod": "^4.1.3"
     },
     "devDependencies": {
         "drizzle-kit": "^0.31.4",

--- a/packages/db/src/local-storage.ts
+++ b/packages/db/src/local-storage.ts
@@ -1,18 +1,65 @@
-import { promises as fs } from 'fs';
+import { promises as fs, Dirent, constants as fsConstants } from 'fs';
 import path from 'path';
-import { env } from '../../web/client/src/env';
+import { z } from 'zod';
+import { DefaultSettings } from '@onlook/constants';
+import type { ChatSuggestion } from '@onlook/models';
+
+export interface LocalBrandColor {
+  id: string;
+  value: string;
+  label?: string;
+}
+
+export interface LocalBrandFont {
+  id: string;
+  family: string;
+  files: string[];
+  styles?: string[];
+  weights?: string[];
+  displayName?: string;
+}
+
+export interface LocalBrandState {
+  colors: LocalBrandColor[];
+  fonts: LocalBrandFont[];
+  updatedAt: string;
+}
 
 export interface LocalProject {
   id: string;
   name: string;
-  description?: string;
+  description?: string | null;
   tags: string[];
   createdAt: string;
   updatedAt: string;
-  previewImgUrl?: string;
-  previewImgPath?: string;
-  sandboxId?: string;
-  sandboxUrl?: string;
+  previewImgUrl?: string | null;
+  previewImgPath?: string | null;
+  sandboxId?: string | null;
+  sandboxUrl?: string | null;
+  version: number;
+  brand: LocalBrandState;
+}
+
+export interface LocalBrandUpdate {
+  colors?: LocalBrandColor[];
+  fonts?: LocalBrandFont[];
+}
+
+export interface LocalBranch {
+  id: string;
+  projectId: string;
+  name: string;
+  description?: string | null;
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt: string;
+  sandboxId?: string | null;
+  sandboxUrl?: string | null;
+}
+
+export interface LocalCanvasState {
+  scale: number;
+  position: { x: number; y: number };
 }
 
 export interface LocalCanvas {
@@ -21,14 +68,19 @@ export interface LocalCanvas {
   name: string;
   createdAt: string;
   updatedAt: string;
+  frames: LocalFrame[];
+  state: LocalCanvasState;
 }
 
 export interface LocalFrame {
   id: string;
+  projectId: string;
   canvasId: string;
+  branchId: string;
   name: string;
-  width: number;
-  height: number;
+  position: { x: number; y: number };
+  dimension: { width: number; height: number };
+  url: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -36,168 +88,1404 @@ export interface LocalFrame {
 export interface LocalConversation {
   id: string;
   projectId: string;
-  title: string;
+  title: string | null;
   createdAt: string;
   updatedAt: string;
+  suggestions: ChatSuggestion[];
 }
 
-export interface LocalMessage {
+export type LocalConversationMessageRole = 'user' | 'assistant' | 'system';
+
+export interface LocalConversationMessage {
   id: string;
   conversationId: string;
-  role: 'user' | 'assistant';
   content: string;
   createdAt: string;
+  role: LocalConversationMessageRole;
+  context: unknown[];
+  parts: unknown[];
+  checkpoints: unknown[];
+  applied?: boolean | null;
+  commitOid?: string | null;
+  snapshots?: unknown;
+}
+
+interface LocalConversationFile extends LocalConversation {
+  version: number;
+  messages: LocalConversationMessage[];
 }
 
 export class LocalStorage {
   private projectsDir: string;
 
-  constructor() {
-    this.projectsDir = env.ONLOOK_PROJECTS_DIR;
-    this.ensureProjectsDir();
+  private readonly ready: Promise<void>;
+
+  private readonly projectDirIndex = new Map<string, string>();
+
+  private readonly largeAssetHintedProjects = new Set<string>();
+
+  private static readonly PROJECT_META_VERSION = 2;
+  private static readonly CONVERSATION_FILE_VERSION = 1;
+
+  private static readonly brandSchema = z
+    .object({
+      colors: z
+        .array(
+          z.object({
+            id: z.string(),
+            value: z.string(),
+            label: z.string().optional(),
+          })
+        )
+        .default([]),
+      fonts: z
+        .array(
+          z.object({
+            id: z.string(),
+            family: z.string(),
+            files: z.array(z.string()).default([]),
+            styles: z.array(z.string()).optional(),
+            weights: z.array(z.string()).optional(),
+            displayName: z.string().optional(),
+          })
+        )
+        .default([]),
+      updatedAt: z.string().default(() => new Date().toISOString()),
+    })
+    .default({ colors: [], fonts: [], updatedAt: new Date().toISOString() });
+
+  private static readonly projectMetaSchema = z
+    .object({
+      version: z
+        .number()
+        .int()
+        .positive()
+        .default(LocalStorage.PROJECT_META_VERSION),
+      id: z.string(),
+      name: z.string(),
+      description: z.string().optional().nullable(),
+      tags: z.array(z.string()).default([]),
+      createdAt: z.string(),
+      updatedAt: z.string(),
+      previewImgUrl: z.string().optional().nullable(),
+      previewImgPath: z.string().optional().nullable(),
+      sandboxId: z.string().optional().nullable(),
+      sandboxUrl: z.string().optional().nullable(),
+      brand: LocalStorage.brandSchema,
+    })
+    .transform((data) => ({
+      ...data,
+      description: data.description ?? undefined,
+      previewImgUrl: data.previewImgUrl ?? undefined,
+      previewImgPath: data.previewImgPath ?? undefined,
+      sandboxId: data.sandboxId ?? undefined,
+      sandboxUrl: data.sandboxUrl ?? undefined,
+    }));
+
+  private static readonly canvasStateSchema = z
+    .object({
+      scale: z.coerce.number().default(() => DefaultSettings.SCALE),
+      position: z
+        .object({
+          x: z.coerce.number(),
+          y: z.coerce.number(),
+        })
+        .default(() => ({
+          x: DefaultSettings.PAN_POSITION.x,
+          y: DefaultSettings.PAN_POSITION.y,
+        })),
+    })
+    .transform((state): LocalCanvasState => ({
+      scale: state.scale,
+      position: {
+        x: state.position.x,
+        y: state.position.y,
+      },
+    }));
+
+  private static readonly canvasFrameSchema = z.object({
+    id: z.string(),
+    projectId: z.string(),
+    canvasId: z.string(),
+    branchId: z.string(),
+    name: z.string().default('Frame'),
+    position: z.object({
+      x: z.coerce.number(),
+      y: z.coerce.number(),
+    }),
+    dimension: z.object({
+      width: z.coerce.number(),
+      height: z.coerce.number(),
+    }),
+    url: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  });
+
+  private static readonly canvasFileSchema = z
+    .object({
+      id: z.string(),
+      projectId: z.string(),
+      name: z.string(),
+      createdAt: z.string(),
+      updatedAt: z.string(),
+      frames: z.array(LocalStorage.canvasFrameSchema).default([]),
+      state: LocalStorage.canvasStateSchema.default(() =>
+        LocalStorage.defaultCanvasState()
+      ),
+    })
+    .transform((data): LocalCanvas => ({
+      id: data.id,
+      projectId: data.projectId,
+      name: data.name,
+      createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+      frames: data.frames.map((frame) => ({
+        ...frame,
+        name: frame.name ?? 'Frame',
+      })),
+      state: data.state,
+    }));
+
+  private static defaultCanvasState(): LocalCanvasState {
+    return {
+      scale: DefaultSettings.SCALE,
+      position: {
+        x: DefaultSettings.PAN_POSITION.x,
+        y: DefaultSettings.PAN_POSITION.y,
+      },
+    };
   }
 
-  private async ensureProjectsDir() {
+  private static readonly conversationMessageSchema = z.object({
+    id: z.string(),
+    conversationId: z.string(),
+    content: z.string(),
+    createdAt: z.string(),
+    role: z.enum(['user', 'assistant', 'system']),
+    context: z.array(z.unknown()).default([]),
+    parts: z.array(z.unknown()).default([]),
+    checkpoints: z.array(z.unknown()).default([]),
+    applied: z.boolean().nullable().optional(),
+    commitOid: z.string().nullable().optional(),
+    snapshots: z.unknown().optional(),
+  });
+
+  private static readonly conversationFileSchema = z
+    .object({
+      version: z
+        .number()
+        .int()
+        .positive()
+        .default(LocalStorage.CONVERSATION_FILE_VERSION),
+      id: z.string(),
+      projectId: z.string(),
+      title: z.string().nullable().optional(),
+      createdAt: z.string(),
+      updatedAt: z.string(),
+      suggestions: z.array(z.unknown()).default([]),
+      messages: z.array(LocalStorage.conversationMessageSchema).default([]),
+    })
+    .transform((data): LocalConversationFile => ({
+      version: data.version ?? LocalStorage.CONVERSATION_FILE_VERSION,
+      id: data.id,
+      projectId: data.projectId,
+      title: data.title ?? null,
+      createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+      suggestions: (data.suggestions ?? []) as ChatSuggestion[],
+      messages: data.messages.map((message) => ({
+        ...message,
+        context: message.context ?? [],
+        parts: message.parts ?? [],
+        checkpoints: message.checkpoints ?? [],
+      })),
+    }));
+
+  constructor(projectsDir?: string) {
+    this.projectsDir = projectsDir ?? '';
+    this.ready = this.initialize(projectsDir).catch((error) => {
+      console.error('Failed to initialize local storage directory:', error);
+      throw error;
+    });
+  }
+
+  private static readonly PERMISSIONS_DOC_PATH = 'docs/macos-permissions.md';
+
+  private async initialize(providedPath?: string): Promise<void> {
+    const resolvedProjectsDir =
+      providedPath ?? (await LocalStorage.resolveDefaultProjectsDir());
+
+    this.projectsDir = resolvedProjectsDir;
+    await this.ensureAccess(this.projectsDir, {
+      intent: 'write',
+      createIfMissing: true,
+      kind: 'directory',
+    });
+    await this.refreshProjectIndex();
+  }
+
+  private static async resolveDefaultProjectsDir(): Promise<string> {
     try {
-      await fs.mkdir(this.projectsDir, { recursive: true });
+      const { env } = await import('../../../apps/web/client/src/env');
+      return env.ONLOOK_PROJECTS_DIR;
     } catch (error) {
-      console.error('Failed to create projects directory:', error);
+      const fallback = process.env.ONLOOK_PROJECTS_DIR;
+      if (fallback && fallback.trim()) {
+        return LocalStorage.expandHomePath(fallback);
+      }
+
+      const home = process.env.HOME;
+      return home ? path.join(home, 'Onlook Projects') : './onlook-projects';
     }
   }
 
-  private getProjectPath(projectId: string): string {
-    return path.join(this.projectsDir, projectId);
+  private static expandHomePath(rawValue: string): string {
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      return trimmed;
+    }
+
+    const homeDirectory = process.env.HOME;
+    if (!homeDirectory) {
+      return trimmed;
+    }
+
+    if (trimmed === '~') {
+      return homeDirectory;
+    }
+
+    if (trimmed.startsWith('~/')) {
+      return path.join(homeDirectory, trimmed.slice(2));
+    }
+
+    if (trimmed.startsWith('$HOME')) {
+      const remainder = trimmed.slice('$HOME'.length);
+      if (!remainder) {
+        return homeDirectory;
+      }
+
+      return path.join(homeDirectory, remainder.replace(/^[/\\]/, ''));
+    }
+
+    return trimmed;
   }
 
-  private getProjectMetaPath(projectId: string): string {
-    return path.join(this.getProjectPath(projectId), 'meta.json');
+  private static getErrorCode(error: unknown): string | undefined {
+    if (!error || typeof error !== 'object') {
+      return undefined;
+    }
+
+    const maybeErrno = error as Partial<NodeJS.ErrnoException>;
+    return typeof maybeErrno.code === 'string' ? maybeErrno.code : undefined;
   }
 
-  private getCanvasPath(projectId: string, canvasId: string): string {
-    return path.join(this.getProjectPath(projectId), 'canvases', `${canvasId}.json`);
+  private static isPermissionError(error: unknown): boolean {
+    const code = LocalStorage.getErrorCode(error);
+    return code === 'EACCES' || code === 'EPERM';
   }
 
-  private getConversationPath(projectId: string, conversationId: string): string {
-    return path.join(this.getProjectPath(projectId), 'conversations', `${conversationId}.json`);
+  private static permissionDocLink(anchor?: string): string {
+    if (!anchor) {
+      return LocalStorage.PERMISSIONS_DOC_PATH;
+    }
+
+    return `${LocalStorage.PERMISSIONS_DOC_PATH}#${anchor}`;
+  }
+
+  private static formatPermissionMessage(
+    targetPath: string,
+    intent: 'read' | 'write'
+  ): string {
+    const action = intent === 'write' ? 'write to' : 'read from';
+    return [
+      `Onlook cannot ${action} "${targetPath}" due to macOS permissions.`,
+      'Grant Full Disk Access to your terminal (or the Onlook app) under',
+      'System Settings → Privacy & Security → Full Disk Access, then retry.',
+      `See ${LocalStorage.permissionDocLink('full-disk-access')} for a walkthrough.`,
+    ].join(' ');
+  }
+
+  private static formatMissingPathMessage(
+    targetPath: string,
+    kind: 'directory' | 'file'
+  ): string {
+    return [
+      `The configured ${kind} "${targetPath}" does not exist.`,
+      'Create it (use mkdir -p for directories) or update ONLOOK_PROJECTS_DIR',
+      `to point to a valid location. See ${LocalStorage.permissionDocLink(
+        'projects-root-layout'
+      )} for the expected tree.`,
+    ].join(' ');
+  }
+
+  private static formatNotDirectoryMessage(targetPath: string): string {
+    return [
+      `Expected a directory at "${targetPath}" but found a file.`,
+      'Move or remove the file, recreate the folder, and rerun the command.',
+      `See ${LocalStorage.permissionDocLink('projects-root-layout')} for details.`,
+    ].join(' ');
+  }
+
+  private static formatGenericAccessMessage(
+    targetPath: string,
+    error: unknown
+  ): string {
+    const reason = error instanceof Error ? error.message : String(error);
+    return [
+      `Unable to access "${targetPath}": ${reason}.`,
+      `See ${LocalStorage.permissionDocLink()} for troubleshooting steps.`,
+    ].join(' ');
+  }
+
+  private async ensureAccess(
+    targetPath: string,
+    options: {
+      intent?: 'read' | 'write';
+      createIfMissing?: boolean;
+      kind?: 'directory' | 'file';
+    } = {}
+  ): Promise<void> {
+    const { intent = 'read', createIfMissing = false, kind = 'directory' } = options;
+    const resolvedPath = path.resolve(targetPath);
+    const mode =
+      intent === 'write' ? fsConstants.W_OK | fsConstants.R_OK : fsConstants.R_OK;
+
+    try {
+      await fs.access(resolvedPath, mode);
+    } catch (error) {
+      const code = LocalStorage.getErrorCode(error);
+      if (code === 'ENOENT') {
+        if (createIfMissing && kind === 'directory') {
+          try {
+            await fs.mkdir(resolvedPath, { recursive: true });
+            await fs.access(resolvedPath, mode);
+          } catch (creationError) {
+            if (LocalStorage.isPermissionError(creationError)) {
+              throw new Error(LocalStorage.formatPermissionMessage(resolvedPath, intent));
+            }
+
+            throw new Error(
+              LocalStorage.formatGenericAccessMessage(resolvedPath, creationError)
+            );
+          }
+
+          return;
+        }
+
+        throw new Error(LocalStorage.formatMissingPathMessage(resolvedPath, kind));
+      }
+
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(LocalStorage.formatPermissionMessage(resolvedPath, intent));
+      }
+
+      throw new Error(LocalStorage.formatGenericAccessMessage(resolvedPath, error));
+    }
+
+    if (kind === 'directory') {
+      try {
+        const stats = await fs.stat(resolvedPath);
+        if (!stats.isDirectory()) {
+          throw new Error(LocalStorage.formatNotDirectoryMessage(resolvedPath));
+        }
+      } catch (error) {
+        const code = LocalStorage.getErrorCode(error);
+        if (code === 'ENOENT') {
+          throw new Error(LocalStorage.formatMissingPathMessage(resolvedPath, kind));
+        }
+
+        if (LocalStorage.isPermissionError(error)) {
+          throw new Error(LocalStorage.formatPermissionMessage(resolvedPath, intent));
+        }
+
+        throw new Error(LocalStorage.formatGenericAccessMessage(resolvedPath, error));
+      }
+    }
+  }
+
+  private async ensureReady(): Promise<void> {
+    await this.ready;
+  }
+
+  private static defaultBrandState(): LocalBrandState {
+    const now = new Date().toISOString();
+    return { colors: [], fonts: [], updatedAt: now };
+  }
+
+  private async writeProjectMeta(
+    projectDir: string,
+    project: LocalProject
+  ): Promise<void> {
+    const metaPath = this.getMetaPathFromDir(projectDir);
+    await this.writeFileSafely(metaPath, JSON.stringify(project, null, 2));
+  }
+
+  private async writeFileSafely(
+    targetPath: string,
+    content: string | Uint8Array
+  ): Promise<void> {
+    const directory = path.dirname(targetPath);
+    await this.ensureAccess(directory, {
+      intent: 'write',
+      createIfMissing: true,
+      kind: 'directory',
+    });
+
+    try {
+      await fs.writeFile(targetPath, content);
+    } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(LocalStorage.formatPermissionMessage(targetPath, 'write'));
+      }
+
+      throw new Error(LocalStorage.formatGenericAccessMessage(targetPath, error));
+    }
+  }
+
+  private normalizeProjectName(name: string | undefined): string {
+    const fallback = 'Untitled Project';
+    if (!name) {
+      return fallback;
+    }
+
+    const trimmed = name.trim();
+    return trimmed || fallback;
+  }
+
+  private toDirectoryName(name: string): string {
+    const normalized = this.normalizeProjectName(name);
+    const sanitized = normalized.replace(/[<>:"/\\|?*\x00-\x1F]/g, '-');
+    const withoutTrailing = sanitized.replace(/[. ]+$/g, '');
+    return withoutTrailing || 'Untitled Project';
+  }
+
+  private getMetaPathFromDir(projectDir: string): string {
+    return path.join(projectDir, 'meta.json');
+  }
+
+  private async readProjectMeta(projectDir: string): Promise<LocalProject | null> {
+    try {
+      const data = await fs.readFile(this.getMetaPathFromDir(projectDir), 'utf-8');
+      const raw = JSON.parse(data) as unknown;
+      const parsed = LocalStorage.projectMetaSchema.safeParse(raw);
+      if (!parsed.success) {
+        console.warn(
+          '[onlook-local-storage] Failed to parse project meta, ignoring project',
+          parsed.error
+        );
+        return null;
+      }
+
+      const needsMigration =
+        (typeof raw === 'object' && raw !== null &&
+          (raw as Record<string, unknown>).version !== LocalStorage.PROJECT_META_VERSION) ||
+        !(typeof raw === 'object' && raw !== null && 'brand' in (raw as Record<string, unknown>));
+
+      const project: LocalProject = {
+        ...parsed.data,
+        version: LocalStorage.PROJECT_META_VERSION,
+        brand: {
+          ...parsed.data.brand,
+          updatedAt: parsed.data.brand.updatedAt || new Date().toISOString(),
+        },
+      };
+
+      if (needsMigration) {
+        await this.writeProjectMeta(projectDir, project);
+      }
+
+      return project;
+    } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(
+          LocalStorage.formatPermissionMessage(
+            this.getMetaPathFromDir(projectDir),
+            'read'
+          )
+        );
+      }
+      return null;
+    }
+  }
+
+  private async pathExists(targetPath: string): Promise<boolean> {
+    try {
+      await fs.access(targetPath);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  private async refreshProjectIndex(): Promise<void> {
+    this.projectDirIndex.clear();
+
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(this.projectsDir, { withFileTypes: true });
+    } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(LocalStorage.formatPermissionMessage(this.projectsDir, 'read'));
+      }
+
+      throw new Error(LocalStorage.formatGenericAccessMessage(this.projectsDir, error));
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const projectDir = path.join(this.projectsDir, entry.name);
+      const project = await this.readProjectMeta(projectDir);
+      if (project) {
+        this.projectDirIndex.set(project.id, projectDir);
+      }
+    }
+  }
+
+  private async getProjectDir(projectId: string): Promise<string | null> {
+    const existing = this.projectDirIndex.get(projectId);
+    if (existing) {
+      return existing;
+    }
+
+    await this.refreshProjectIndex();
+    return this.projectDirIndex.get(projectId) ?? null;
+  }
+
+  private async requireProjectDir(projectId: string): Promise<string> {
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      throw new Error(`Project directory not found for id ${projectId}`);
+    }
+    return projectDir;
+  }
+
+  private async ensureProjectStructure(projectDir: string): Promise<void> {
+    await this.ensureAccess(projectDir, {
+      intent: 'write',
+      createIfMissing: true,
+      kind: 'directory',
+    });
+
+    const directories = ['files', 'canvases', 'conversations', 'previews', 'assets', 'branches'];
+    for (const directory of directories) {
+      const target = path.join(projectDir, directory);
+      await this.ensureAccess(target, {
+        intent: 'write',
+        createIfMissing: true,
+        kind: 'directory',
+      });
+    }
+
+    await this.maybeRecommendAssetSymlink(path.join(projectDir, 'assets'));
+  }
+
+  private async maybeRecommendAssetSymlink(assetDir: string): Promise<void> {
+    const resolvedAssetDir = path.resolve(assetDir);
+    if (this.largeAssetHintedProjects.has(resolvedAssetDir)) {
+      return;
+    }
+
+    const thresholdBytes = 200 * 1024 * 1024;
+
+    try {
+      const entries = await fs.readdir(resolvedAssetDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile()) {
+          continue;
+        }
+
+        const entryPath = path.join(resolvedAssetDir, entry.name);
+        try {
+          const stats = await fs.stat(entryPath);
+          if (stats.size >= thresholdBytes) {
+            this.largeAssetHintedProjects.add(resolvedAssetDir);
+            const sizeInMb = stats.size / (1024 * 1024);
+            console.warn(
+              `[onlook-local-storage] "${entryPath}" is ${sizeInMb.toFixed(
+                1
+              )}MB. Consider symlinking large binaries into the assets folder instead of copying them. See ${LocalStorage.permissionDocLink(
+                'large-assets-and-symlinks'
+              )} for guidance.`
+            );
+            break;
+          }
+        } catch (statError) {
+          if (LocalStorage.isPermissionError(statError)) {
+            throw new Error(LocalStorage.formatPermissionMessage(entryPath, 'read'));
+          }
+        }
+      }
+    } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(LocalStorage.formatPermissionMessage(resolvedAssetDir, 'read'));
+      }
+      // Ignore missing directories; ensureAccess already created them when needed.
+    }
+  }
+
+  private async getUniqueProjectDir(
+    baseName: string,
+    currentProjectId?: string
+  ): Promise<{ dirName: string; dirPath: string }> {
+    const targetDir = currentProjectId
+      ? await this.getProjectDir(currentProjectId)
+      : null;
+
+    let attempt = 0;
+    let candidateName = baseName;
+
+    while (true) {
+      const candidatePath = path.join(this.projectsDir, candidateName);
+      if (!(await this.pathExists(candidatePath))) {
+        return { dirName: candidateName, dirPath: candidatePath };
+      }
+
+      if (targetDir && path.resolve(candidatePath) === path.resolve(targetDir)) {
+        return { dirName: candidateName, dirPath: candidatePath };
+      }
+
+      attempt += 1;
+      candidateName = `${baseName} (${attempt})`;
+    }
   }
 
   // Project operations
-  async createProject(project: Omit<LocalProject, 'id' | 'createdAt' | 'updatedAt'>): Promise<LocalProject> {
-    const id = this.generateId();
+  async createProject(
+    project: Omit<LocalProject, 'id' | 'createdAt' | 'updatedAt' | 'version' | 'brand'>
+  ): Promise<LocalProject> {
+    await this.ensureReady();
+
     const now = new Date().toISOString();
+    const name = this.normalizeProjectName(project.name);
+    const directoryBase = this.toDirectoryName(name);
+    const { dirPath } = await this.getUniqueProjectDir(directoryBase);
+
+    await this.ensureProjectStructure(dirPath);
+
+    const id = this.generateId();
     const fullProject: LocalProject = {
       ...project,
+      name,
       id,
       createdAt: now,
       updatedAt: now,
+      version: LocalStorage.PROJECT_META_VERSION,
+      brand: LocalStorage.defaultBrandState(),
     };
 
-    const projectPath = this.getProjectPath(id);
-    await fs.mkdir(projectPath, { recursive: true });
-    await fs.mkdir(path.join(projectPath, 'canvases'), { recursive: true });
-    await fs.mkdir(path.join(projectPath, 'conversations'), { recursive: true });
-    await fs.mkdir(path.join(projectPath, 'files'), { recursive: true });
+    await this.writeProjectMeta(dirPath, fullProject);
 
-    await fs.writeFile(
-      this.getProjectMetaPath(id),
-      JSON.stringify(fullProject, null, 2)
-    );
+    this.projectDirIndex.set(id, dirPath);
+
+    await this.ensureDefaultBranch(fullProject, dirPath);
 
     return fullProject;
   }
 
   async getProject(projectId: string): Promise<LocalProject | null> {
-    try {
-      const metaPath = this.getProjectMetaPath(projectId);
-      const data = await fs.readFile(metaPath, 'utf-8');
-      return JSON.parse(data);
-    } catch (error) {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
       return null;
     }
+
+    const project = await this.readProjectMeta(projectDir);
+    if (!project) {
+      return null;
+    }
+
+    await this.ensureProjectStructure(projectDir);
+    return project;
   }
 
-  async updateProject(projectId: string, updates: Partial<Omit<LocalProject, 'id' | 'createdAt'>>): Promise<LocalProject | null> {
+  async updateProject(
+    projectId: string,
+    updates: Partial<Omit<LocalProject, 'id' | 'createdAt' | 'version'>>
+  ): Promise<LocalProject | null> {
+    await this.ensureReady();
+
     const project = await this.getProject(projectId);
-    if (!project) return null;
+    if (!project) {
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    const brandUpdate =
+      'brand' in updates && updates.brand
+        ? {
+            colors: updates.brand.colors ?? project.brand.colors,
+            fonts: updates.brand.fonts ?? project.brand.fonts,
+            updatedAt: new Date().toISOString(),
+          }
+        : project.brand;
 
     const updatedProject: LocalProject = {
       ...project,
       ...updates,
-      updatedAt: new Date().toISOString(),
+      brand: brandUpdate,
+      name: updates.name ? this.normalizeProjectName(updates.name) : project.name,
+      updatedAt: now,
+      version: LocalStorage.PROJECT_META_VERSION,
     };
 
-    await fs.writeFile(
-      this.getProjectMetaPath(projectId),
-      JSON.stringify(updatedProject, null, 2)
+    const currentDir = await this.requireProjectDir(projectId);
+    const targetDirName = this.toDirectoryName(updatedProject.name);
+    const { dirPath: targetDir } = await this.getUniqueProjectDir(
+      targetDirName,
+      projectId
     );
+
+    if (path.resolve(currentDir) !== path.resolve(targetDir)) {
+      await this.ensureAccess(path.dirname(targetDir), {
+        intent: 'write',
+        createIfMissing: true,
+        kind: 'directory',
+      });
+
+      try {
+        await fs.rename(currentDir, targetDir);
+      } catch (error) {
+        if (LocalStorage.isPermissionError(error)) {
+          throw new Error(LocalStorage.formatPermissionMessage(targetDir, 'write'));
+        }
+
+        throw new Error(LocalStorage.formatGenericAccessMessage(targetDir, error));
+      }
+      this.projectDirIndex.set(projectId, targetDir);
+    }
+
+    await this.ensureProjectStructure(targetDir);
+    await this.writeProjectMeta(targetDir, updatedProject);
 
     return updatedProject;
   }
 
-  async deleteProject(projectId: string): Promise<boolean> {
+  async updateBrand(
+    projectId: string,
+    updates: LocalBrandUpdate
+  ): Promise<LocalProject | null> {
+    const project = await this.getProject(projectId);
+    if (!project) {
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    const updatedProject: LocalProject = {
+      ...project,
+      brand: {
+        colors: updates.colors ?? project.brand.colors,
+        fonts: updates.fonts ?? project.brand.fonts,
+        updatedAt: now,
+      },
+      updatedAt: now,
+      version: LocalStorage.PROJECT_META_VERSION,
+    };
+
+    const projectDir = await this.requireProjectDir(projectId);
+    await this.writeProjectMeta(projectDir, updatedProject);
+    return updatedProject;
+  }
+
+  private getBranchPath(projectDir: string, branchId: string): string {
+    return path.join(projectDir, 'branches', `${branchId}.json`);
+  }
+
+  private getConversationPath(projectDir: string, conversationId: string): string {
+    return path.join(projectDir, 'conversations', `${conversationId}.json`);
+  }
+
+  private async ensureDefaultBranch(
+    project: LocalProject,
+    projectDir: string
+  ): Promise<void> {
+    const branches = await this.listBranches(project.id);
+    if (branches.length > 0) {
+      return;
+    }
+
+    const defaultBranch: Omit<LocalBranch, 'id' | 'createdAt' | 'updatedAt'> = {
+      projectId: project.id,
+      name: 'main',
+      description: null,
+      isDefault: true,
+      sandboxId: null,
+      sandboxUrl: null,
+    };
+
+    const now = new Date().toISOString();
+    const branch: LocalBranch = {
+      ...defaultBranch,
+      id: this.generateId(),
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.writeFileSafely(
+      this.getBranchPath(projectDir, branch.id),
+      JSON.stringify(branch, null, 2)
+    );
+  }
+
+  async createBranch(
+    projectId: string,
+    branch: Omit<LocalBranch, 'id' | 'createdAt' | 'updatedAt' | 'projectId'>
+  ): Promise<LocalBranch> {
+    await this.ensureReady();
+
+    const projectDir = await this.requireProjectDir(projectId);
+    await this.ensureAccess(path.join(projectDir, 'branches'), {
+      intent: 'write',
+      createIfMissing: true,
+      kind: 'directory',
+    });
+
+    const now = new Date().toISOString();
+    const id = this.generateId();
+    const fullBranch: LocalBranch = {
+      ...branch,
+      projectId,
+      id,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.writeFileSafely(
+      this.getBranchPath(projectDir, id),
+      JSON.stringify(fullBranch, null, 2)
+    );
+
+    return fullBranch;
+  }
+
+  async listBranches(projectId: string): Promise<LocalBranch[]> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return [];
+    }
+
+    await this.ensureAccess(path.join(projectDir, 'branches'), {
+      intent: 'read',
+      createIfMissing: true,
+      kind: 'directory',
+    });
+
     try {
-      const projectPath = this.getProjectPath(projectId);
-      await fs.rm(projectPath, { recursive: true, force: true });
+      const entries = await fs.readdir(path.join(projectDir, 'branches'), {
+        withFileTypes: true,
+      });
+
+      const branches: LocalBranch[] = [];
+      for (const entry of entries) {
+        if (!entry.isFile() || !entry.name.endsWith('.json')) {
+          continue;
+        }
+
+        const filePath = path.join(projectDir, 'branches', entry.name);
+        try {
+          const raw = await fs.readFile(filePath, 'utf-8');
+          branches.push(JSON.parse(raw) as LocalBranch);
+        } catch (error) {
+          if (LocalStorage.isPermissionError(error)) {
+            throw new Error(LocalStorage.formatPermissionMessage(filePath, 'read'));
+          }
+          console.warn('[onlook-local-storage] Failed to parse branch file', filePath, error);
+        }
+      }
+
+      return branches.sort(
+        (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      );
+    } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(
+          LocalStorage.formatPermissionMessage(path.join(projectDir, 'branches'), 'read')
+        );
+      }
+
+      throw new Error(
+        LocalStorage.formatGenericAccessMessage(path.join(projectDir, 'branches'), error)
+      );
+    }
+  }
+
+  async updateBranch(
+    projectId: string,
+    branchId: string,
+    updates: Partial<Omit<LocalBranch, 'id' | 'projectId' | 'createdAt'>>
+  ): Promise<LocalBranch | null> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return null;
+    }
+
+    const branchPath = this.getBranchPath(projectDir, branchId);
+    try {
+      const raw = await fs.readFile(branchPath, 'utf-8');
+      const branch = JSON.parse(raw) as LocalBranch;
+      const updated: LocalBranch = {
+        ...branch,
+        ...updates,
+        updatedAt: new Date().toISOString(),
+      };
+
+      await this.writeFileSafely(branchPath, JSON.stringify(updated, null, 2));
+      return updated;
+    } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(LocalStorage.formatPermissionMessage(branchPath, 'write'));
+      }
+      return null;
+    }
+  }
+
+  async deleteBranch(projectId: string, branchId: string): Promise<boolean> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return false;
+    }
+
+    const branchPath = this.getBranchPath(projectDir, branchId);
+    try {
+      await fs.rm(branchPath, { force: true });
       return true;
     } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(LocalStorage.formatPermissionMessage(branchPath, 'write'));
+      }
+      return false;
+    }
+  }
+
+  private async writeCanvasFile(
+    projectDir: string,
+    canvas: LocalCanvas
+  ): Promise<void> {
+    const normalized = LocalStorage.canvasFileSchema.parse({
+      ...canvas,
+      state: {
+        scale: canvas.state.scale,
+        position: {
+          x: canvas.state.position.x,
+          y: canvas.state.position.y,
+        },
+      },
+      frames: canvas.frames.map((frame) => ({
+        ...frame,
+        position: {
+          x: frame.position.x,
+          y: frame.position.y,
+        },
+        dimension: {
+          width: frame.dimension.width,
+          height: frame.dimension.height,
+        },
+      })),
+    });
+
+    await this.writeFileSafely(
+      path.join(projectDir, 'canvases', `${normalized.id}.json`),
+      JSON.stringify(normalized, null, 2)
+    );
+  }
+
+  private async maybeMigrateLegacyFrames(
+    projectDir: string,
+    canvas: LocalCanvas
+  ): Promise<LocalCanvas> {
+    if (canvas.frames.length > 0) {
+      return canvas;
+    }
+
+    const legacyDir = path.join(projectDir, 'frames');
+    if (!(await this.pathExists(legacyDir))) {
+      return canvas;
+    }
+
+    let migrated = false;
+    const migratedFrames: LocalFrame[] = [];
+
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(legacyDir, { withFileTypes: true });
+    } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(LocalStorage.formatPermissionMessage(legacyDir, 'read'));
+      }
+      return canvas;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.json')) {
+        continue;
+      }
+
+      const filePath = path.join(legacyDir, entry.name);
+      try {
+        const raw = await fs.readFile(filePath, 'utf-8');
+        const parsed = LocalStorage.canvasFrameSchema.parse({
+          projectId: canvas.projectId,
+          canvasId: canvas.id,
+          ...JSON.parse(raw),
+        });
+
+        if (parsed.canvasId !== canvas.id) {
+          continue;
+        }
+
+        migratedFrames.push({
+          ...parsed,
+          projectId: parsed.projectId ?? canvas.projectId,
+        });
+        migrated = true;
+        await fs.rm(filePath, { force: true }).catch(() => undefined);
+      } catch (error) {
+        if (LocalStorage.isPermissionError(error)) {
+          throw new Error(LocalStorage.formatPermissionMessage(filePath, 'read'));
+        }
+        console.warn('[onlook-local-storage] Failed to migrate legacy frame file', filePath, error);
+      }
+    }
+
+    if (!migrated || migratedFrames.length === 0) {
+      return canvas;
+    }
+
+    const updatedCanvas: LocalCanvas = {
+      ...canvas,
+      frames: migratedFrames,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.writeCanvasFile(projectDir, updatedCanvas);
+    return updatedCanvas;
+  }
+
+  async createFrame(
+    frame: Omit<LocalFrame, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<LocalFrame> {
+    await this.ensureReady();
+
+    const projectDir = await this.requireProjectDir(frame.projectId);
+    const canvas = await this.getCanvas(frame.projectId, frame.canvasId);
+
+    if (!canvas) {
+      throw new Error(`Canvas ${frame.canvasId} not found for project ${frame.projectId}`);
+    }
+
+    const now = new Date().toISOString();
+    const id = this.generateId();
+    const fullFrame: LocalFrame = {
+      ...frame,
+      id,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const updatedCanvas: LocalCanvas = {
+      ...canvas,
+      updatedAt: now,
+      frames: [...canvas.frames, fullFrame],
+    };
+
+    await this.writeCanvasFile(projectDir, updatedCanvas);
+
+    return fullFrame;
+  }
+
+  async listFrames(
+    projectId: string,
+    filters: { canvasId?: string; branchId?: string } = {}
+  ): Promise<LocalFrame[]> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return [];
+    }
+
+    if (filters.canvasId) {
+      const canvas = await this.getCanvas(projectId, filters.canvasId);
+      if (!canvas) {
+        return [];
+      }
+
+      return canvas.frames
+        .filter((frame) =>
+          filters.branchId ? frame.branchId === filters.branchId : true
+        )
+        .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    }
+
+    const canvases = await this.listCanvases(projectId);
+    const frames = canvases.flatMap((canvas) => canvas.frames);
+
+    return frames
+      .filter((frame) => (filters.branchId ? frame.branchId === filters.branchId : true))
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+  }
+
+  async updateFrame(
+    projectId: string,
+    frameId: string,
+    updates: Partial<Omit<LocalFrame, 'id' | 'projectId' | 'createdAt'>>
+  ): Promise<LocalFrame | null> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return null;
+    }
+
+    const canvases = await this.listCanvases(projectId);
+    for (const canvas of canvases) {
+      const index = canvas.frames.findIndex((frame) => frame.id === frameId);
+      if (index === -1) {
+        continue;
+      }
+
+      const existing = canvas.frames[index]!;
+      const updated: LocalFrame = {
+        ...existing,
+        ...updates,
+        position: updates.position ?? existing.position,
+        dimension: updates.dimension ?? existing.dimension,
+        canvasId: updates.canvasId ?? existing.canvasId,
+        branchId: updates.branchId ?? existing.branchId,
+        url: updates.url ?? existing.url,
+        name: updates.name ?? existing.name,
+        updatedAt: new Date().toISOString(),
+      };
+
+      const updatedCanvas: LocalCanvas = {
+        ...canvas,
+        updatedAt: updated.updatedAt,
+        frames: [
+          ...canvas.frames.slice(0, index),
+          updated,
+          ...canvas.frames.slice(index + 1),
+        ],
+      };
+
+      await this.writeCanvasFile(projectDir, updatedCanvas);
+      return updated;
+    }
+
+    return null;
+  }
+
+  async deleteFrame(projectId: string, frameId: string): Promise<boolean> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return false;
+    }
+
+    const canvases = await this.listCanvases(projectId);
+    for (const canvas of canvases) {
+      const index = canvas.frames.findIndex((frame) => frame.id === frameId);
+      if (index === -1) {
+        continue;
+      }
+
+      const updatedCanvas: LocalCanvas = {
+        ...canvas,
+        updatedAt: new Date().toISOString(),
+        frames: [
+          ...canvas.frames.slice(0, index),
+          ...canvas.frames.slice(index + 1),
+        ],
+      };
+
+      await this.writeCanvasFile(projectDir, updatedCanvas);
+      return true;
+    }
+
+    return false;
+  }
+
+  async findFrame(
+    frameId: string
+  ): Promise<{ frame: LocalFrame; canvas: LocalCanvas; projectId: string } | null> {
+    await this.ensureReady();
+    await this.refreshProjectIndex();
+
+    for (const [projectId] of this.projectDirIndex) {
+      const canvases = await this.listCanvases(projectId);
+      for (const canvas of canvases) {
+        const frame = canvas.frames.find((item) => item.id === frameId);
+        if (frame) {
+          return { frame, canvas, projectId };
+        }
+      }
+    }
+
+    return null;
+  }
+
+  async findCanvasById(
+    canvasId: string
+  ): Promise<{ canvas: LocalCanvas; projectId: string } | null> {
+    await this.ensureReady();
+    await this.refreshProjectIndex();
+
+    for (const [projectId] of this.projectDirIndex) {
+      const canvas = await this.getCanvas(projectId, canvasId);
+      if (canvas) {
+        return { canvas, projectId };
+      }
+    }
+
+    return null;
+  }
+
+  async deleteProject(projectId: string): Promise<boolean> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return false;
+    }
+
+    try {
+      await fs.rm(projectDir, { recursive: true, force: true });
+      this.projectDirIndex.delete(projectId);
+      return true;
+    } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(LocalStorage.formatPermissionMessage(projectDir, 'write'));
+      }
       console.error('Failed to delete project:', error);
       return false;
     }
   }
 
   async listProjects(): Promise<LocalProject[]> {
-    try {
-      const entries = await fs.readdir(this.projectsDir, { withFileTypes: true });
-      const projects: LocalProject[] = [];
+    await this.ensureReady();
 
-      for (const entry of entries) {
-        if (entry.isDirectory()) {
-          const project = await this.getProject(entry.name);
-          if (project) {
-            projects.push(project);
-          }
-        }
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(this.projectsDir, { withFileTypes: true });
+    } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(LocalStorage.formatPermissionMessage(this.projectsDir, 'read'));
       }
 
-      return projects.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
-    } catch (error) {
-      console.error('Failed to list projects:', error);
-      return [];
+      throw new Error(LocalStorage.formatGenericAccessMessage(this.projectsDir, error));
     }
+
+    const projects: LocalProject[] = [];
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const projectDir = path.join(this.projectsDir, entry.name);
+      const project = await this.readProjectMeta(projectDir);
+      if (project) {
+        this.projectDirIndex.set(project.id, projectDir);
+        await this.ensureProjectStructure(projectDir);
+        projects.push(project);
+      }
+    }
+
+    return projects.sort(
+      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    );
   }
 
   // Canvas operations
-  async createCanvas(canvas: Omit<LocalCanvas, 'id' | 'createdAt' | 'updatedAt'>): Promise<LocalCanvas> {
+  async createCanvas(
+    canvas: Omit<LocalCanvas, 'id' | 'createdAt' | 'updatedAt' | 'frames' | 'state'> & {
+      frames?: LocalFrame[];
+      state?: Partial<LocalCanvasState>;
+    }
+  ): Promise<LocalCanvas> {
+    await this.ensureReady();
+
+    const projectDir = await this.requireProjectDir(canvas.projectId);
+    await this.ensureProjectStructure(projectDir);
+
     const id = this.generateId();
     const now = new Date().toISOString();
-    const fullCanvas: LocalCanvas = {
+    const normalized = LocalStorage.canvasFileSchema.parse({
       ...canvas,
+      frames: canvas.frames ?? [],
+      state: {
+        scale: canvas.state?.scale ?? DefaultSettings.SCALE,
+        position: {
+          x: canvas.state?.position?.x ?? DefaultSettings.PAN_POSITION.x,
+          y: canvas.state?.position?.y ?? DefaultSettings.PAN_POSITION.y,
+        },
+      },
       id,
       createdAt: now,
       updatedAt: now,
-    };
+    });
 
-    await fs.writeFile(
-      this.getCanvasPath(canvas.projectId, id),
-      JSON.stringify(fullCanvas, null, 2)
+    await this.writeFileSafely(
+      path.join(projectDir, 'canvases', `${id}.json`),
+      JSON.stringify(normalized, null, 2)
     );
 
-    return fullCanvas;
+    return normalized;
   }
 
-  async getCanvas(projectId: string, canvasId: string): Promise<LocalCanvas | null> {
+  async getCanvas(
+    projectId: string,
+    canvasId: string
+  ): Promise<LocalCanvas | null> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return null;
+    }
+
     try {
-      const canvasPath = this.getCanvasPath(projectId, canvasId);
-      const data = await fs.readFile(canvasPath, 'utf-8');
-      return JSON.parse(data);
+      const data = await fs.readFile(
+        path.join(projectDir, 'canvases', `${canvasId}.json`),
+        'utf-8'
+      );
+      const parsed = LocalStorage.canvasFileSchema.parse(JSON.parse(data));
+      return await this.maybeMigrateLegacyFrames(projectDir, parsed);
     } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(
+          LocalStorage.formatPermissionMessage(
+            path.join(projectDir, 'canvases', `${canvasId}.json`),
+            'read'
+          )
+        );
+      }
       return null;
     }
   }
 
   async listCanvases(projectId: string): Promise<LocalCanvas[]> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return [];
+    }
+
+    await this.ensureProjectStructure(projectDir);
+
     try {
-      const canvasesDir = path.join(this.getProjectPath(projectId), 'canvases');
+      const canvasesDir = path.join(projectDir, 'canvases');
       const entries = await fs.readdir(canvasesDir, { withFileTypes: true });
       const canvases: LocalCanvas[] = [];
 
@@ -211,85 +1499,462 @@ export class LocalStorage {
         }
       }
 
-      return canvases.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      return canvases.sort(
+        (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      );
     } catch (error) {
-      console.error('Failed to list canvases:', error);
-      return [];
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(LocalStorage.formatPermissionMessage(path.join(projectDir, 'canvases'), 'read'));
+      }
+
+      throw new Error(
+        LocalStorage.formatGenericAccessMessage(path.join(projectDir, 'canvases'), error)
+      );
     }
+  }
+
+  async updateCanvasState(
+    projectId: string,
+    canvasId: string,
+    state: Partial<LocalCanvasState>
+  ): Promise<LocalCanvas | null> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return null;
+    }
+
+    const canvas = await this.getCanvas(projectId, canvasId);
+    if (!canvas) {
+      return null;
+    }
+
+    const updatedCanvas: LocalCanvas = {
+      ...canvas,
+      state: {
+        scale: state.scale ?? canvas.state.scale,
+        position: {
+          x: state.position?.x ?? canvas.state.position.x,
+          y: state.position?.y ?? canvas.state.position.y,
+        },
+      },
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.writeCanvasFile(projectDir, updatedCanvas);
+    return updatedCanvas;
   }
 
   // Conversation operations
-  async createConversation(conversation: Omit<LocalConversation, 'id' | 'createdAt' | 'updatedAt'>): Promise<LocalConversation> {
-    const id = this.generateId();
-    const now = new Date().toISOString();
-    const fullConversation: LocalConversation = {
-      ...conversation,
-      id,
-      createdAt: now,
-      updatedAt: now,
+  private toConversationMetadata(file: LocalConversationFile): LocalConversation {
+    return {
+      id: file.id,
+      projectId: file.projectId,
+      title: file.title,
+      createdAt: file.createdAt,
+      updatedAt: file.updatedAt,
+      suggestions: file.suggestions ?? [],
     };
-
-    await fs.writeFile(
-      this.getConversationPath(conversation.projectId, id),
-      JSON.stringify(fullConversation, null, 2)
-    );
-
-    return fullConversation;
   }
 
-  async getConversation(projectId: string, conversationId: string): Promise<LocalConversation | null> {
+  private normalizeStoredMessage(
+    conversationId: string,
+    raw: unknown
+  ): LocalConversationMessage {
+    const value = typeof raw === 'object' && raw ? raw as Record<string, unknown> : {};
+    const createdAt = typeof value.createdAt === 'string' ? value.createdAt : new Date().toISOString();
+    const id = typeof value.id === 'string' ? value.id : this.generateId();
+
+    const parsed = LocalStorage.conversationMessageSchema.parse({
+      ...value,
+      id,
+      conversationId: typeof value.conversationId === 'string' ? value.conversationId : conversationId,
+      createdAt,
+    });
+
+    return {
+      ...parsed,
+      context: parsed.context ?? [],
+      parts: parsed.parts ?? [],
+      checkpoints: parsed.checkpoints ?? [],
+    };
+  }
+
+  private async readConversationFile(
+    projectDir: string,
+    conversationId: string
+  ): Promise<LocalConversationFile | null> {
+    const conversationPath = this.getConversationPath(projectDir, conversationId);
     try {
-      const conversationPath = this.getConversationPath(projectId, conversationId);
-      const data = await fs.readFile(conversationPath, 'utf-8');
-      return JSON.parse(data);
+      const raw = await fs.readFile(conversationPath, 'utf-8');
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+      if (typeof parsed.version !== 'number') {
+        const now = new Date().toISOString();
+        const legacySuggestions = Array.isArray(parsed.suggestions)
+          ? (parsed.suggestions as ChatSuggestion[])
+          : [];
+        const legacyMessages = Array.isArray(parsed.messages)
+          ? (parsed.messages as unknown[]).map((message) =>
+              this.normalizeStoredMessage(conversationId, message)
+            )
+          : [];
+
+        const upgraded: LocalConversationFile = {
+          version: LocalStorage.CONVERSATION_FILE_VERSION,
+          id: typeof parsed.id === 'string' ? parsed.id : conversationId,
+          projectId: typeof parsed.projectId === 'string'
+            ? parsed.projectId
+            : path.basename(projectDir),
+          title: typeof parsed.title === 'string'
+            ? parsed.title
+            : typeof parsed.displayName === 'string'
+              ? (parsed.displayName as string)
+              : null,
+          createdAt: typeof parsed.createdAt === 'string' ? parsed.createdAt : now,
+          updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : now,
+          suggestions: legacySuggestions,
+          messages: legacyMessages,
+        };
+
+        await this.writeConversationFile(projectDir, upgraded);
+        return upgraded;
+      }
+
+      const normalized = LocalStorage.conversationFileSchema.parse(parsed);
+
+      if (normalized.version !== LocalStorage.CONVERSATION_FILE_VERSION) {
+        normalized.version = LocalStorage.CONVERSATION_FILE_VERSION;
+        await this.writeConversationFile(projectDir, normalized);
+      }
+
+      return normalized;
     } catch (error) {
-      return null;
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(
+          LocalStorage.formatPermissionMessage(conversationPath, 'read')
+        );
+      }
+
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        return null;
+      }
+
+      throw new Error(
+        LocalStorage.formatGenericAccessMessage(conversationPath, error)
+      );
     }
   }
 
+  private async writeConversationFile(
+    projectDir: string,
+    conversation: LocalConversationFile
+  ): Promise<void> {
+    const filePath = this.getConversationPath(projectDir, conversation.id);
+    const payload = {
+      ...conversation,
+      title: conversation.title ?? null,
+      suggestions: conversation.suggestions ?? [],
+      messages: conversation.messages.map((message) => ({
+        ...message,
+        context: message.context ?? [],
+        parts: message.parts ?? [],
+        checkpoints: message.checkpoints ?? [],
+      })),
+    } satisfies LocalConversationFile;
+
+    await this.writeFileSafely(filePath, JSON.stringify(payload, null, 2));
+  }
+
+  async createConversation(
+    conversation: { projectId: string; title?: string | null }
+  ): Promise<LocalConversation> {
+    await this.ensureReady();
+
+    const projectDir = await this.requireProjectDir(conversation.projectId);
+    await this.ensureProjectStructure(projectDir);
+
+    const id = this.generateId();
+    const now = new Date().toISOString();
+    const metadata: LocalConversation = {
+      id,
+      projectId: conversation.projectId,
+      title: conversation.title ?? null,
+      createdAt: now,
+      updatedAt: now,
+      suggestions: [],
+    };
+
+    const conversationFile: LocalConversationFile = {
+      ...metadata,
+      version: LocalStorage.CONVERSATION_FILE_VERSION,
+      messages: [],
+    };
+
+    await this.writeConversationFile(projectDir, conversationFile);
+
+    return metadata;
+  }
+
+  async getConversation(
+    projectId: string,
+    conversationId: string
+  ): Promise<LocalConversation | null> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return null;
+    }
+
+    const file = await this.readConversationFile(projectDir, conversationId);
+    if (!file) {
+      return null;
+    }
+
+    return this.toConversationMetadata(file);
+  }
+
   async listConversations(projectId: string): Promise<LocalConversation[]> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return [];
+    }
+
+    await this.ensureProjectStructure(projectDir);
+
     try {
-      const conversationsDir = path.join(this.getProjectPath(projectId), 'conversations');
+      const conversationsDir = path.join(projectDir, 'conversations');
       const entries = await fs.readdir(conversationsDir, { withFileTypes: true });
       const conversations: LocalConversation[] = [];
 
       for (const entry of entries) {
         if (entry.isFile() && entry.name.endsWith('.json')) {
           const conversationId = entry.name.replace('.json', '');
-          const conversation = await this.getConversation(projectId, conversationId);
-          if (conversation) {
-            conversations.push(conversation);
+          const conversationFile = await this.readConversationFile(projectDir, conversationId);
+          if (conversationFile) {
+            conversations.push(this.toConversationMetadata(conversationFile));
           }
         }
       }
 
-      return conversations.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      return conversations.sort(
+        (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      );
     } catch (error) {
-      console.error('Failed to list conversations:', error);
-      return [];
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(
+          LocalStorage.formatPermissionMessage(path.join(projectDir, 'conversations'), 'read')
+        );
+      }
+
+      throw new Error(
+        LocalStorage.formatGenericAccessMessage(path.join(projectDir, 'conversations'), error)
+      );
     }
   }
 
+  async updateConversation(
+    projectId: string,
+    conversationId: string,
+    updates: Partial<Pick<LocalConversation, 'title' | 'suggestions'>>
+  ): Promise<LocalConversation | null> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return null;
+    }
+
+    const conversation = await this.readConversationFile(projectDir, conversationId);
+    if (!conversation) {
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    const updatedConversation: LocalConversationFile = {
+      ...conversation,
+      title: updates.title ?? conversation.title ?? null,
+      suggestions: updates.suggestions ?? conversation.suggestions ?? [],
+      updatedAt: now,
+    };
+
+    await this.writeConversationFile(projectDir, updatedConversation);
+    return this.toConversationMetadata(updatedConversation);
+  }
+
+  async deleteConversation(projectId: string, conversationId: string): Promise<boolean> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return false;
+    }
+
+    const filePath = this.getConversationPath(projectDir, conversationId);
+    try {
+      await fs.unlink(filePath);
+      return true;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        return false;
+      }
+
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(LocalStorage.formatPermissionMessage(filePath, 'write'));
+      }
+
+      throw new Error(LocalStorage.formatGenericAccessMessage(filePath, error));
+    }
+  }
+
+  async listConversationMessages(
+    projectId: string,
+    conversationId: string
+  ): Promise<LocalConversationMessage[]> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return [];
+    }
+
+    const conversation = await this.readConversationFile(projectDir, conversationId);
+    if (!conversation) {
+      return [];
+    }
+
+    return conversation.messages;
+  }
+
+  async replaceConversationMessages(
+    projectId: string,
+    conversationId: string,
+    messages: LocalConversationMessage[]
+  ): Promise<void> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      throw new Error(`Project ${projectId} not found`);
+    }
+
+    const conversation = await this.readConversationFile(projectDir, conversationId);
+    if (!conversation) {
+      throw new Error(`Conversation ${conversationId} not found`);
+    }
+
+    const updated: LocalConversationFile = {
+      ...conversation,
+      messages,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.writeConversationFile(projectDir, updated);
+  }
+
+  async updateConversationMessage(
+    projectId: string,
+    conversationId: string,
+    messageId: string,
+    updates: Partial<Pick<LocalConversationMessage, 'context' | 'parts' | 'checkpoints' | 'content' | 'createdAt'>>
+  ): Promise<void> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      throw new Error(`Project ${projectId} not found`);
+    }
+
+    const conversation = await this.readConversationFile(projectDir, conversationId);
+    if (!conversation) {
+      throw new Error(`Conversation ${conversationId} not found`);
+    }
+
+    const index = conversation.messages.findIndex((message) => message.id === messageId);
+    if (index === -1) {
+      throw new Error(`Message ${messageId} not found`);
+    }
+
+    const existing = conversation.messages[index];
+    const updatedMessage: LocalConversationMessage = {
+      ...existing,
+      ...updates,
+      context: updates.context ?? existing.context ?? [],
+      parts: updates.parts ?? existing.parts ?? [],
+      checkpoints: updates.checkpoints ?? existing.checkpoints ?? [],
+      createdAt: updates.createdAt ?? existing.createdAt,
+    };
+
+    const updatedConversation: LocalConversationFile = {
+      ...conversation,
+      messages: [
+        ...conversation.messages.slice(0, index),
+        updatedMessage,
+        ...conversation.messages.slice(index + 1),
+      ],
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.writeConversationFile(projectDir, updatedConversation);
+  }
+
   // File operations
-  async saveFile(projectId: string, filePath: string, content: string): Promise<void> {
-    const fullPath = path.join(this.getProjectPath(projectId), 'files', filePath);
-    const dir = path.dirname(fullPath);
-    await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(fullPath, content, 'utf-8');
+  async saveFile(
+    projectId: string,
+    filePath: string,
+    content: string
+  ): Promise<void> {
+    await this.ensureReady();
+
+    const projectDir = await this.requireProjectDir(projectId);
+    await this.ensureProjectStructure(projectDir);
+
+    const fullPath = path.join(projectDir, 'files', filePath);
+    await this.writeFileSafely(fullPath, content);
   }
 
   async readFile(projectId: string, filePath: string): Promise<string | null> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return null;
+    }
+
     try {
-      const fullPath = path.join(this.getProjectPath(projectId), 'files', filePath);
+      const fullPath = path.join(projectDir, 'files', filePath);
       return await fs.readFile(fullPath, 'utf-8');
     } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(
+          LocalStorage.formatPermissionMessage(
+            path.join(projectDir, 'files', filePath),
+            'read'
+          )
+        );
+      }
       return null;
     }
   }
 
   async listFiles(projectId: string, dirPath: string = ''): Promise<string[]> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return [];
+    }
+
+    await this.ensureProjectStructure(projectDir);
+
     try {
-      const fullPath = path.join(this.getProjectPath(projectId), 'files', dirPath);
+      const fullPath = path.join(projectDir, 'files', dirPath);
       const entries = await fs.readdir(fullPath, { withFileTypes: true });
       const files: string[] = [];
 
@@ -305,8 +1970,72 @@ export class LocalStorage {
 
       return files;
     } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(
+          LocalStorage.formatPermissionMessage(path.join(projectDir, 'files', dirPath), 'read')
+        );
+      }
+
       return [];
     }
+  }
+
+  private async listDirectory(
+    projectDir: string,
+    baseDir: string,
+    dirPath: string = ''
+  ): Promise<string[]> {
+    const targetDir = path.join(projectDir, baseDir, dirPath);
+    try {
+      const entries = await fs.readdir(targetDir, { withFileTypes: true });
+      const files: string[] = [];
+
+      for (const entry of entries) {
+        const relativePath = path.join(dirPath, entry.name);
+        if (entry.isDirectory()) {
+          const subFiles = await this.listDirectory(projectDir, baseDir, relativePath);
+          files.push(...subFiles);
+        } else {
+          files.push(relativePath);
+        }
+      }
+
+      return files;
+    } catch (error) {
+      if (LocalStorage.isPermissionError(error)) {
+        throw new Error(
+          LocalStorage.formatPermissionMessage(path.join(projectDir, baseDir, dirPath), 'read')
+        );
+      }
+
+      return [];
+    }
+  }
+
+  async listAssets(projectId: string, dirPath: string = ''): Promise<string[]> {
+    await this.ensureReady();
+
+    const projectDir = await this.getProjectDir(projectId);
+    if (!projectDir) {
+      return [];
+    }
+
+    await this.ensureProjectStructure(projectDir);
+    return this.listDirectory(projectDir, 'assets', dirPath);
+  }
+
+  async saveAsset(
+    projectId: string,
+    assetPath: string,
+    content: string | Uint8Array
+  ): Promise<void> {
+    await this.ensureReady();
+
+    const projectDir = await this.requireProjectDir(projectId);
+    await this.ensureProjectStructure(projectDir);
+
+    const fullPath = path.join(projectDir, 'assets', assetPath);
+    await this.writeFileSafely(fullPath, content);
   }
 
   private generateId(): string {

--- a/packages/db/test/local-storage.test.ts
+++ b/packages/db/test/local-storage.test.ts
@@ -1,0 +1,402 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { tmpdir } from 'os';
+import { LocalStorage, type LocalConversationMessage } from '../src/local-storage';
+
+const requiredSubdirectories = [
+  'files',
+  'canvases',
+  'conversations',
+  'previews',
+  'assets',
+  'branches',
+];
+
+const readJson = async <T>(targetPath: string): Promise<T> => {
+  const raw = await fs.readFile(targetPath, 'utf-8');
+  return JSON.parse(raw) as T;
+};
+
+describe('LocalStorage project structure', () => {
+  let baseDir: string;
+  let storage: LocalStorage;
+
+  beforeEach(async () => {
+    baseDir = await fs.mkdtemp(path.join(tmpdir(), 'onlook-local-storage-'));
+    storage = new LocalStorage(baseDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  it('creates a project tree rooted by project name', async () => {
+    const project = await storage.createProject({
+      name: 'Sample Project',
+      description: 'Example project',
+      tags: [],
+    });
+
+    const projectDir = path.join(baseDir, 'Sample Project');
+    const entries = await fs.readdir(projectDir);
+
+    expect(entries).toContain('meta.json');
+
+    for (const subdirectory of requiredSubdirectories) {
+      const stats = await fs.stat(path.join(projectDir, subdirectory));
+      expect(stats.isDirectory()).toBe(true);
+    }
+
+    const meta = await readJson<typeof project>(path.join(projectDir, 'meta.json'));
+    expect(meta.id).toBe(project.id);
+    expect(meta.name).toBe('Sample Project');
+  });
+
+  it('repairs missing project subdirectories when accessed', async () => {
+    const project = await storage.createProject({
+      name: 'Repair Project',
+      description: undefined,
+      tags: [],
+    });
+
+    const projectDir = path.join(baseDir, 'Repair Project');
+
+    await fs.rm(path.join(projectDir, 'files'), { recursive: true, force: true });
+    await fs.rm(path.join(projectDir, 'canvases'), { recursive: true, force: true });
+    await fs.rm(path.join(projectDir, 'conversations'), { recursive: true, force: true });
+
+    const fetched = await storage.getProject(project.id);
+    expect(fetched?.id).toBe(project.id);
+
+    for (const subdirectory of requiredSubdirectories) {
+      const stats = await fs.stat(path.join(projectDir, subdirectory));
+      expect(stats.isDirectory()).toBe(true);
+    }
+  });
+});
+
+describe('LocalStorage left panel state persistence', () => {
+  let baseDir: string;
+  let storage: LocalStorage;
+
+  beforeEach(async () => {
+    baseDir = await fs.mkdtemp(path.join(tmpdir(), 'onlook-left-panel-'));
+    storage = new LocalStorage(baseDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  it('persists brand colors and fonts via meta.json', async () => {
+    const project = await storage.createProject({
+      name: 'Brand Project',
+      description: 'Brand state',
+      tags: [],
+    });
+
+    const updated = await storage.updateBrand(project.id, {
+      colors: [
+        { id: 'primary', value: '#ff0000', label: 'Primary Red' },
+        { id: 'secondary', value: '#00ff00' },
+      ],
+      fonts: [
+        {
+          id: 'inter',
+          family: 'Inter',
+          files: ['fonts/inter.woff2'],
+          styles: ['normal'],
+          weights: ['400', '700'],
+        },
+      ],
+    });
+
+    expect(updated?.brand.colors).toHaveLength(2);
+    expect(updated?.brand.fonts).toHaveLength(1);
+
+    const reloaded = new LocalStorage(baseDir);
+    const fetched = await reloaded.getProject(project.id);
+    expect(fetched?.brand.colors).toEqual(updated?.brand.colors);
+    expect(fetched?.brand.fonts).toEqual(updated?.brand.fonts);
+  });
+
+  it('creates, lists, and updates branches for the branches tab', async () => {
+    const project = await storage.createProject({
+      name: 'Branch Project',
+      description: undefined,
+      tags: [],
+    });
+
+    const defaultBranches = await storage.listBranches(project.id);
+    expect(defaultBranches.length).toBeGreaterThanOrEqual(1);
+
+    const newBranch = await storage.createBranch(project.id, {
+      name: 'feature/login',
+      description: 'Login flow work',
+      isDefault: false,
+      sandboxId: 'sandbox-123',
+      sandboxUrl: 'http://localhost:3000',
+    });
+
+    const branches = await storage.listBranches(project.id);
+    expect(branches.find((branch) => branch.id === newBranch.id)).toBeDefined();
+
+    await storage.updateBranch(project.id, newBranch.id, {
+      description: 'Updated description',
+    });
+
+    const reloaded = new LocalStorage(baseDir);
+    const reloadedBranches = await reloaded.listBranches(project.id);
+    const reloadedBranch = reloadedBranches.find((branch) => branch.id === newBranch.id);
+    expect(reloadedBranch?.description).toBe('Updated description');
+  });
+
+  it('stores frames for the layers tab', async () => {
+    const project = await storage.createProject({
+      name: 'Layers Project',
+      description: undefined,
+      tags: [],
+    });
+
+    const canvas = await storage.createCanvas({
+      projectId: project.id,
+      name: 'Canvas A',
+    });
+
+    const branch = (await storage.listBranches(project.id))[0];
+    expect(branch).toBeDefined();
+
+    const frame = await storage.createFrame({
+      projectId: project.id,
+      canvasId: canvas.id,
+      branchId: branch.id,
+      name: 'Frame 1',
+      position: { x: 0, y: 0 },
+      dimension: { width: 1200, height: 800 },
+      url: '/app/page',
+    });
+
+    const frames = await storage.listFrames(project.id, { canvasId: canvas.id });
+    expect(frames.map((f) => f.id)).toContain(frame.id);
+
+    const reloaded = new LocalStorage(baseDir);
+    const persisted = await reloaded.listFrames(project.id, { branchId: branch.id });
+    expect(persisted.map((f) => f.id)).toContain(frame.id);
+
+    const canvases = await reloaded.listCanvases(project.id);
+    expect(canvases[0]?.frames.map((f) => f.id)).toContain(frame.id);
+  });
+
+  it('persists multiple frames for a canvas across reloads', async () => {
+    const project = await storage.createProject({
+      name: 'Multi Frame Project',
+      description: undefined,
+      tags: [],
+    });
+
+    const canvas = await storage.createCanvas({
+      projectId: project.id,
+      name: 'Canvas B',
+    });
+
+    const branch = (await storage.listBranches(project.id))[0]!;
+
+    const desktop = await storage.createFrame({
+      projectId: project.id,
+      canvasId: canvas.id,
+      branchId: branch.id,
+      name: 'Desktop',
+      position: { x: 120, y: 80 },
+      dimension: { width: 1440, height: 960 },
+      url: 'http://localhost:3000',
+    });
+
+    const mobile = await storage.createFrame({
+      projectId: project.id,
+      canvasId: canvas.id,
+      branchId: branch.id,
+      name: 'Mobile',
+      position: { x: 1820, y: 80 },
+      dimension: { width: 440, height: 956 },
+      url: 'http://localhost:3000',
+    });
+
+    const reloaded = new LocalStorage(baseDir);
+    const frames = await reloaded.listFrames(project.id, { canvasId: canvas.id });
+
+    const frameIds = frames.map((f) => f.id);
+    expect(frameIds).toEqual(expect.arrayContaining([desktop.id, mobile.id]));
+
+    const [desktopFrame] = frames.filter((f) => f.id === desktop.id);
+    expect(desktopFrame?.dimension.width).toBe(1440);
+    expect(desktopFrame?.dimension.height).toBe(960);
+
+    const canvasWithFrames = (await reloaded.listCanvases(project.id))[0];
+    expect(canvasWithFrames?.frames).toHaveLength(2);
+  });
+
+  it('saves project files used by the pages tab', async () => {
+    const project = await storage.createProject({
+      name: 'Pages Project',
+      description: undefined,
+      tags: [],
+    });
+
+    await storage.saveFile(project.id, path.join('app', 'page.tsx'), 'export default function Page() {}');
+    await storage.saveFile(
+      project.id,
+      path.join('app', 'blog', '[slug]', 'page.tsx'),
+      'export default function BlogPage() {}'
+    );
+
+    const files = await storage.listFiles(project.id);
+    expect(files).toEqual(
+      expect.arrayContaining(['app/page.tsx', path.join('app', 'blog', '[slug]', 'page.tsx')])
+    );
+  });
+
+  it('tracks assets for the images tab', async () => {
+    const project = await storage.createProject({
+      name: 'Images Project',
+      description: undefined,
+      tags: [],
+    });
+
+    await storage.saveAsset(project.id, path.join('images', 'logo.png'), new Uint8Array([0, 1, 2]));
+    await storage.saveAsset(project.id, 'hero.jpg', new Uint8Array([5, 4, 3]));
+
+    const assets = await storage.listAssets(project.id);
+    expect(assets).toEqual(expect.arrayContaining(['images/logo.png', 'hero.jpg']));
+  });
+});
+
+describe('LocalStorage conversation transcripts', () => {
+  let baseDir: string;
+  let storage: LocalStorage;
+
+  beforeEach(async () => {
+    baseDir = await fs.mkdtemp(path.join(tmpdir(), 'onlook-conversation-'));
+    storage = new LocalStorage(baseDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  it('persists conversation messages and metadata updates', async () => {
+    const project = await storage.createProject({
+      name: 'Chat Project',
+      description: 'Conversation persistence',
+      tags: [],
+    });
+
+    const conversation = await storage.createConversation({
+      projectId: project.id,
+      title: 'Initial Chat',
+    });
+
+    const now = new Date().toISOString();
+    const messages: LocalConversationMessage[] = [
+      {
+        id: 'm1',
+        conversationId: conversation.id,
+        content: 'Hello world',
+        role: 'user',
+        createdAt: now,
+        context: [],
+        parts: [],
+        checkpoints: [],
+      },
+      {
+        id: 'm2',
+        conversationId: conversation.id,
+        content: 'Welcome to Onlook',
+        role: 'assistant',
+        createdAt: now,
+        context: [],
+        parts: [],
+        checkpoints: [],
+      },
+    ];
+
+    await storage.replaceConversationMessages(project.id, conversation.id, messages);
+
+    const loadedMessages = await storage.listConversationMessages(project.id, conversation.id);
+    expect(loadedMessages.map((msg) => msg.content)).toEqual([
+      'Hello world',
+      'Welcome to Onlook',
+    ]);
+
+    const updatedConversation = await storage.updateConversation(project.id, conversation.id, {
+      title: 'Updated Chat',
+      suggestions: [
+        {
+          title: 'Refine hero section',
+          prompt: 'Tighten the hero copy and ensure the CTA stands out.',
+        },
+      ],
+    });
+
+    expect(updatedConversation?.title).toBe('Updated Chat');
+    expect(updatedConversation?.suggestions).toHaveLength(1);
+
+    const checkpointCreatedAt = new Date().toISOString();
+    await storage.updateConversationMessage(project.id, conversation.id, 'm1', {
+      checkpoints: [
+        {
+          type: 'git',
+          oid: 'abc123',
+          createdAt: checkpointCreatedAt,
+        },
+      ],
+    });
+
+    const reloaded = new LocalStorage(baseDir);
+    const persistedMessages = await reloaded.listConversationMessages(project.id, conversation.id);
+    expect(persistedMessages).toHaveLength(2);
+    const reloadedMessage = persistedMessages.find((msg) => msg.id === 'm1');
+    expect(reloadedMessage?.checkpoints).toHaveLength(1);
+
+    const persistedConversation = await reloaded.getConversation(project.id, conversation.id);
+    expect(persistedConversation?.title).toBe('Updated Chat');
+    expect(persistedConversation?.suggestions[0]?.title).toBe('Refine hero section');
+
+    const deleted = await reloaded.deleteConversation(project.id, conversation.id);
+    expect(deleted).toBe(true);
+    const afterDeletion = await reloaded.listConversationMessages(project.id, conversation.id);
+    expect(afterDeletion).toHaveLength(0);
+  });
+});
+
+describe('LocalStorage access guidance', () => {
+  it('surfaced message references Full Disk Access when the root directory is blocked', async () => {
+    const blockedPath = path.join(tmpdir(), 'onlook-permission-denied');
+    const accessError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    const accessSpy = spyOn(fs, 'access').mockRejectedValue(accessError);
+
+    try {
+      const storage = new LocalStorage(blockedPath);
+      await expect(storage.listProjects()).rejects.toThrow(
+        /macos-permissions\.md#full-disk-access/i
+      );
+    } finally {
+      accessSpy.mockRestore();
+      await fs.rm(blockedPath, { recursive: true, force: true });
+    }
+  });
+
+  it('reminds the user when the configured root path is a file', async () => {
+    const filePath = path.join(tmpdir(), 'onlook-file-root');
+    await fs.writeFile(filePath, 'not a directory');
+
+    try {
+      const storage = new LocalStorage(filePath);
+      await expect(storage.listProjects()).rejects.toThrow(
+        /macos-permissions\.md#projects-root-layout/i
+      );
+    } finally {
+      await fs.rm(filePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/smoke-dev.mjs
+++ b/scripts/smoke-dev.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { setTimeout as delay } from 'node:timers/promises';
+import { spawn } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const clientDir = resolve(repoRoot, 'apps', 'web', 'client');
+const DEV_URL = 'http://127.0.0.1:3000';
+const HEALTH_URL = `${DEV_URL}/api/health`;
+const PAGE_URL = `${DEV_URL}/`;
+const PAGE_PATH = resolve(clientDir, 'src', 'app', 'page.tsx');
+const MARKER_TARGET = 'Welcome to Onlook';
+
+function pipeStream(stream, target) {
+    if (!stream) return;
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => target.write(chunk));
+}
+
+async function waitFor(checkFn, attempts, intervalMs) {
+    for (let i = 0; i < attempts; i += 1) {
+        if (await checkFn()) {
+            return true;
+        }
+        await delay(intervalMs);
+    }
+    return false;
+}
+
+async function waitForHealth() {
+    const ok = await waitFor(async () => {
+        try {
+            const res = await fetch(HEALTH_URL, { cache: 'no-store' });
+            return res.ok;
+        } catch (error) {
+            return false;
+        }
+    }, 60, 1000);
+
+    if (!ok) {
+        throw new Error('Timed out waiting for /api/health');
+    }
+}
+
+async function waitForMarker(marker) {
+    const ok = await waitFor(async () => {
+        try {
+            const res = await fetch(PAGE_URL, {
+                headers: {
+                    'cache-control': 'no-cache',
+                    pragma: 'no-cache',
+                },
+            });
+            if (!res.ok) {
+                return false;
+            }
+            const body = await res.text();
+            return body.includes(marker);
+        } catch (error) {
+            return false;
+        }
+    }, 60, 1000);
+
+    if (!ok) {
+        throw new Error('Hot reload did not propagate marker');
+    }
+}
+
+async function main() {
+    const devProcess = spawn('bun', ['run', 'dev'], {
+        cwd: clientDir,
+        env: {
+            ...process.env,
+            NEXT_TELEMETRY_DISABLED: '1',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let devExited = false;
+    let devExitCode = null;
+    let devExitError;
+
+    devProcess.on('exit', (code) => {
+        devExited = true;
+        devExitCode = code;
+    });
+    devProcess.on('error', (error) => {
+        devExitError = error;
+    });
+
+    pipeStream(devProcess.stdout, process.stdout);
+    pipeStream(devProcess.stderr, process.stderr);
+
+    let originalPage = '';
+    let pageModified = false;
+
+    try {
+        await waitForHealth();
+        console.log('Health check passed');
+
+        originalPage = await readFile(PAGE_PATH, 'utf8');
+        if (!originalPage.includes(MARKER_TARGET)) {
+            throw new Error(`Unable to find marker target "${MARKER_TARGET}" in page.tsx`);
+        }
+
+        const marker = `hot reload marker ${Date.now()}`;
+        const updatedPage = originalPage.replace(MARKER_TARGET, `${MARKER_TARGET} ${marker}`);
+
+        if (updatedPage === originalPage) {
+            throw new Error('Failed to apply marker update to page.tsx');
+        }
+
+        await writeFile(PAGE_PATH, updatedPage, 'utf8');
+        pageModified = true;
+
+        await waitForMarker(marker);
+        console.log('hot reload active');
+        console.log('Smoke test complete');
+    } finally {
+        if (pageModified) {
+            await writeFile(PAGE_PATH, originalPage, 'utf8');
+        }
+
+        if (!devExited) {
+            devProcess.kill('SIGTERM');
+            await new Promise((resolve) => {
+                devProcess.once('exit', resolve);
+            });
+        }
+
+        if (devExitError) {
+            throw devExitError;
+        }
+
+        if (devExitCode !== 0 && devExitCode !== null) {
+            throw new Error(`Dev server exited with code ${devExitCode}`);
+        }
+    }
+}
+
+main().catch((error) => {
+    console.error(error instanceof Error ? error.stack ?? error.message : error);
+    process.exitCode = 1;
+});

--- a/tooling/scripts/setup-check.ts
+++ b/tooling/scripts/setup-check.ts
@@ -1,0 +1,108 @@
+import { promises as fs, constants as fsConstants } from "fs";
+import os from "os";
+import path from "path";
+
+const statusSymbols = {
+    pass: "✅",
+    fail: "❌",
+    info: "ℹ️"
+} as const;
+
+type Status = keyof typeof statusSymbols;
+
+type CheckResult = {
+    label: string;
+    status: Status;
+    note: string;
+};
+
+const results: CheckResult[] = [];
+
+const bunVersion = Bun.version;
+results.push({
+    label: "Bun",
+    status: "pass",
+    note: `v${bunVersion}`
+});
+
+const platform = process.platform;
+const isMac = platform === "darwin";
+results.push({
+    label: "Platform",
+    status: "info",
+    note: isMac ? "macOS" : `${platform} (non-macOS)`
+});
+
+const homeDirectory = os.homedir();
+const projectsDirName = "Onlook Projects";
+const projectsDir = path.join(homeDirectory, projectsDirName);
+
+let projectsStatus: Status = "pass";
+let projectsNote = "";
+
+try {
+    await fs.mkdir(projectsDir, { recursive: true });
+    await fs.access(projectsDir, fsConstants.W_OK);
+    projectsNote = `Writable at ${projectsDir}${isMac ? "" : " (checked outside macOS)"}`;
+} catch (error) {
+    projectsStatus = "fail";
+    const message = error instanceof Error ? error.message : String(error);
+    projectsNote = `Failed to verify access at ${projectsDir}: ${message}`;
+}
+
+results.push({
+    label: "~/Onlook Projects",
+    status: projectsStatus,
+    note: projectsNote
+});
+
+const envLocalRelativePath = path.join("apps", "web", "client", ".env.local");
+const envLocalPath = path.join(process.cwd(), envLocalRelativePath);
+const envLocalContents = [
+    "NODE_ENV=development",
+    "NEXT_PUBLIC_SITE_URL=http://localhost:3000",
+    "ONLOOK_PROJECTS_DIR=\"$HOME/Onlook Projects\"",
+    ""
+].join("\n");
+
+let envLocalStatus: Status = "pass";
+let envLocalNote = "";
+
+try {
+    await fs.access(envLocalPath, fsConstants.F_OK);
+    envLocalNote = `Found ${envLocalRelativePath}`;
+} catch {
+    try {
+        await fs.writeFile(envLocalPath, envLocalContents, { flag: "wx" });
+        envLocalNote = `Created ${envLocalRelativePath}`;
+    } catch (error) {
+        envLocalStatus = "fail";
+        const message = error instanceof Error ? error.message : String(error);
+        envLocalNote = `Unable to create ${envLocalRelativePath}: ${message}`;
+    }
+}
+
+results.push({
+    label: ".env.local",
+    status: envLocalStatus,
+    note: envLocalNote
+});
+
+const lines: string[] = [
+    "# Setup Check",
+    "",
+    `Generated: ${new Date().toISOString()}`,
+    "",
+    ...results.map(({ label, status, note }) => `- ${statusSymbols[status]} ${label}: ${note}`),
+    ""
+];
+
+await fs.writeFile("SETUP_CHECK.md", lines.join("\n"), "utf8");
+
+for (const { label, status, note } of results) {
+    console.log(`${statusSymbols[status]} ${label}: ${note}`);
+}
+
+if (results.some(({ status }) => status === "fail")) {
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary
- restructure the local storage canvas model to persist frame arrays, viewport state, and migrate any legacy frame files
- switch the frame and user canvas tRPC routers to read and update data via the filesystem-backed storage layer while seeding default desktop/mobile frames for new projects
- cover multi-frame save and reload behaviour in the local storage tests

## Testing
- bun test packages/db/test/local-storage.test.ts *(fails: Cannot find package 'zod' from packages/db/src/local-storage.ts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3dae000f8832c86153a1e5095ff13