### PR TITLE
feat: add local sandbox runtime and logs panel

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/bottom-bar/sandbox-logs-panel.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/bottom-bar/sandbox-logs-panel.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEditorEngine } from '@/components/store/editor';
+import { Button } from '@onlook/ui/button';
+import { cn } from '@onlook/ui/utils';
+import type { LocalSandboxLogEntry, LocalSandboxLogLevel } from '@onlook/code-provider';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+type LogLevelFilter = 'all' | LocalSandboxLogLevel;
+
+interface DisplayLogEntry {
+    id: string;
+    level: LocalSandboxLogLevel;
+    message: string;
+    timestamp: string;
+}
+
+const LEVEL_OPTIONS: { label: string; value: LogLevelFilter }[] = [
+    { label: 'All', value: 'all' },
+    { label: 'Info', value: 'info' },
+    { label: 'Warn', value: 'warn' },
+    { label: 'Error', value: 'error' },
+];
+
+const LEVEL_CLASS: Record<LocalSandboxLogLevel, string> = {
+    info: 'text-foreground-secondary',
+    warn: 'text-amber-400',
+    error: 'text-red-400',
+};
+
+function parseRemoteLogs(rawLogs: string): DisplayLogEntry[] {
+    const lines = rawLogs.split(/\r?\n/).filter(Boolean);
+    return lines.map((line, index) => {
+        const lowered = line.toLowerCase();
+        let level: LocalSandboxLogLevel = 'info';
+        if (lowered.includes('error')) {
+            level = 'error';
+        } else if (lowered.includes('warn')) {
+            level = 'warn';
+        }
+        const timestampMatch = line.match(/\[(\d{1,2}:\d{2}:\d{2})\]/);
+        const timestamp = timestampMatch?.[1] ?? '';
+        return {
+            id: `${index}-${line}`,
+            level,
+            message: line,
+            timestamp,
+        };
+    });
+}
+
+function normalizeLocalLogs(entries: LocalSandboxLogEntry[]): DisplayLogEntry[] {
+    return entries.map((entry, index) => ({
+        id: `${entry.timestamp.getTime()}-${index}`,
+        level: entry.level,
+        message: entry.message,
+        timestamp: entry.timestamp.toLocaleTimeString([], { hour12: false }),
+    }));
+}
+
+export function SandboxLogsPanel({
+    hidden,
+}: {
+    hidden: boolean;
+}) {
+    const editorEngine = useEditorEngine();
+    const [level, setLevel] = useState<LogLevelFilter>('all');
+    const [logs, setLogs] = useState<DisplayLogEntry[]>([]);
+    const unsubscribeRef = useRef<(() => void) | null>(null);
+
+    useEffect(() => {
+        if (hidden) {
+            setLogs([]);
+            unsubscribeRef.current?.();
+            unsubscribeRef.current = null;
+            return;
+        }
+        const activeBranch = editorEngine.branches.activeBranch;
+        const sandbox = activeBranch ? editorEngine.branches.getSandboxById(activeBranch.id) : null;
+        if (!sandbox?.session) {
+            setLogs([]);
+            return;
+        }
+
+        const loadLogs = async () => {
+            try {
+                const result = await sandbox.session.readDevServerLogs(level);
+                if (Array.isArray(result)) {
+                    setLogs(normalizeLocalLogs(result).slice(-200));
+                } else if (typeof result === 'string') {
+                    setLogs(parseRemoteLogs(result).slice(-200));
+                }
+            } catch (error) {
+                console.error('Failed to read sandbox logs:', error);
+            }
+        };
+
+        loadLogs();
+
+        unsubscribeRef.current?.();
+        unsubscribeRef.current = sandbox.session.subscribeToDevServerLogs(level, (entry) => {
+            setLogs(prev => {
+                const next = [...prev, ...normalizeLocalLogs([entry])];
+                if (next.length > 200) {
+                    return next.slice(next.length - 200);
+                }
+                return next;
+            });
+        });
+
+        return () => {
+            unsubscribeRef.current?.();
+            unsubscribeRef.current = null;
+        };
+    }, [editorEngine, level, hidden]);
+
+    const groupedLogs = useMemo(() => logs, [logs]);
+
+    return (
+        <div
+            className={cn(
+                'flex h-full w-full flex-col border border-border/40 rounded-lg bg-background/95 backdrop-blur transition-opacity duration-200',
+                hidden ? 'opacity-0 pointer-events-none' : 'opacity-100'
+            )}
+        >
+            <div className="flex items-center justify-between border-b border-border/40 px-3 py-2">
+                <span className="text-xs font-medium text-foreground-secondary">Sandbox Logs</span>
+                <div className="flex items-center gap-1">
+                    {LEVEL_OPTIONS.map((option) => (
+                        <Button
+                            key={option.value}
+                            variant={level === option.value ? 'default' : 'ghost'}
+                            size="sm"
+                            onClick={() => setLevel(option.value)}
+                            className={cn(
+                                'h-7 px-2 text-xs',
+                                level === option.value
+                                    ? 'bg-foreground/10 text-foreground'
+                                    : 'text-foreground-secondary hover:text-foreground'
+                            )}
+                        >
+                            {option.label}
+                        </Button>
+                    ))}
+                </div>
+            </div>
+            <div className="flex-1 overflow-auto px-3 py-2 text-xs font-mono">
+                {groupedLogs.length === 0 ? (
+                    <div className="flex h-full items-center justify-center text-foreground-tertiary">
+                        No logs available
+                    </div>
+                ) : (
+                    <ul className="space-y-1">
+                        {groupedLogs.map((entry) => (
+                            <li key={entry.id} className="flex gap-2">
+                                <span className="text-[10px] text-foreground-tertiary min-w-[48px]">
+                                    {entry.timestamp}
+                                </span>
+                                <span className={cn('flex-1 break-words', LEVEL_CLASS[entry.level])}>{entry.message}</span>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/web/client/src/app/projects/import/local/_context/index.tsx
+++ b/apps/web/client/src/app/projects/import/local/_context/index.tsx
@@ -139,7 +139,11 @@ export const ProjectCreationProvider = ({
                         initClient: true,
                         keepActiveWhileConnected: false,
                         getSession: async (sandboxId) => {
-                            return startSandbox({ sandboxId });
+                            const result = await startSandbox({ sandboxId });
+                            if (result.provider !== CodeProvider.CodeSandbox) {
+                                throw new Error('Expected CodeSandbox provider when importing project');
+                            }
+                            return result.session;
                         },
                     },
                 },

--- a/apps/web/client/src/components/tools/handlers/sandbox.ts
+++ b/apps/web/client/src/components/tools/handlers/sandbox.ts
@@ -1,7 +1,6 @@
 import type { EditorEngine } from '@/components/store/editor/engine';
-import {
-    SANDBOX_TOOL_PARAMETERS
-} from '@onlook/ai';
+import { SANDBOX_TOOL_PARAMETERS } from '@onlook/ai';
+import type { LocalSandboxLogEntry } from '@onlook/code-provider';
 import { z } from 'zod';
 
 export async function handleSandboxTool(args: z.infer<typeof SANDBOX_TOOL_PARAMETERS>, editorEngine: EditorEngine): Promise<string> {
@@ -20,6 +19,14 @@ export async function handleSandboxTool(args: z.infer<typeof SANDBOX_TOOL_PARAME
             }
         } else if (args.command === 'read_dev_server_logs') {
             const logs = await sandbox.session.readDevServerLogs();
+            if (Array.isArray(logs)) {
+                return logs
+                    .map((entry: LocalSandboxLogEntry) => {
+                        const timestamp = entry.timestamp.toISOString();
+                        return `[${timestamp}] [${entry.level.toUpperCase()}] ${entry.message}`;
+                    })
+                    .join('\n');
+            }
             return logs;
         } else {
             throw new Error('Invalid command');

--- a/docs/sandbox-local.md
+++ b/docs/sandbox-local.md
@@ -1,0 +1,27 @@
+# Local Sandbox Orchestration
+
+This document captures the end-to-end flow for starting, restarting, and inspecting a local sandbox instance on macOS. It focuses on the Phase 4 pipeline where the browser UI coordinates with the Next.js API layer and the `@onlook/code-provider` runtime to manage a Bun-powered dev server without relying on Docker.
+
+## Start Flow
+
+1. **Session manager bootstraps** – When a project view loads, the client-side [`SessionManager`](apps/web/client/src/components/store/editor/sandbox/session.ts) immediately invokes `start` with the branch sandbox ID. The method guards against duplicate connections and requests a fresh session by calling `api.sandbox.start.mutate({ sandboxId })`.
+2. **Router selects provider** – The API endpoint [`sandboxRouter.start`](apps/web/client/src/server/api/routers/project/sandbox.ts) inspects the sandbox ID. IDs that begin with `local-` are treated as macOS sandboxes and resolved to a `LocalProvider`. The router sanitizes the ID, builds a project directory beneath `env.ONLOOK_PROJECTS_DIR`, and instantiates the provider with that path plus a preferred port.
+3. **Local provider spins up Bun** – Inside [`LocalProvider`](packages/code-provider/src/providers/local/index.ts) the runtime ensures the project folder exists, finds an open port (auto-incrementing when conflicts occur), and spawns `bun run dev` with `PORT` injected. Stdout/stderr are streamed into a bounded log buffer (200 entries by default) and exposed through task and subscription APIs.
+4. **Client hydrates provider** – Back in the browser, the session manager caches the initial `LocalCreateSessionOutput`, then creates a `LocalProvider` client with a `getSession` hook that reuses the cached payload for the first handshake and falls back to `api.sandbox.start` for later refreshes. Terminal sessions are initialized once the provider resolves.
+
+## Restart Flow
+
+- The **Restart Sandbox** button (`apps/web/client/src/app/project/[id]/_components/bottom-bar/restart-sandbox-button.tsx`) defers to `sandbox.session.restartDevServer()`, which routes through `LocalProvider.getTask('dev').restart()`. The runtime gracefully sends `SIGTERM`, escalates to `SIGKILL` after a five second grace period, and respawns the Bun process on the previously negotiated port. Preview frames refresh after a short delay to avoid transient 502s.
+
+## Port Management
+
+- Ports are requested via `preferredPort` (defaults to 3000). [`findAvailablePort`](packages/code-provider/src/providers/local/index.ts) probes sequentially until a free port is found, ensuring the sandbox starts even when other services occupy the default. The resolved port is cached in the session payload so later restarts remain on the same address. API helpers sanitize sandbox IDs and root directories to prevent path traversal.
+
+## Logs Pipeline
+
+- The local runtime pushes stdout/stderr lines into an in-memory ring buffer while annotating each entry with a log level (`info`, `warn`, `error`) and timestamp.
+- The UI exposes these diagnostics through the new [`SandboxLogsPanel`](apps/web/client/src/app/project/[id]/_components/bottom-bar/sandbox-logs-panel.tsx). Users can toggle the panel from the terminal toolbar, filter by level, and watch streaming updates via `SessionManager.subscribeToDevServerLogs`. Remote sandboxes fall back to the existing task output (`task.open()`), so the panel still renders when the provider is CodeSandbox.
+
+## Cleanup
+
+- `sandboxRouter.delete` and `sandboxRouter.hibernate` reuse the same provider detection and call `LocalProvider.stopProject()` to tear down the Bun process when a branch is deleted or hibernated. `LocalRuntimeRegistry` removes the runtime entry so subsequent starts create a fresh instance.

--- a/packages/code-provider/src/index.ts
+++ b/packages/code-provider/src/index.ts
@@ -1,9 +1,23 @@
 import { CodeProvider } from './providers';
-import { LocalProvider, type LocalProviderOptions } from './providers/local';
+import {
+    LocalProvider,
+    type LocalCreateSessionOutput,
+    type LocalProviderGetSession,
+    type LocalProviderOptions,
+    type LocalSandboxLogEntry,
+    type LocalSandboxLogLevel,
+} from './providers/local';
 import { CodesandboxProvider, type CodesandboxProviderOptions } from './providers/codesandbox';
 import { NodeFsProvider, type NodeFsProviderOptions } from './providers/nodefs';
 export * from './providers';
 export { LocalProvider } from './providers/local';
+export type {
+    LocalProviderOptions,
+    LocalProviderGetSession,
+    LocalCreateSessionOutput,
+    LocalSandboxLogEntry,
+    LocalSandboxLogLevel,
+} from './providers/local';
 export { CodesandboxProvider } from './providers/codesandbox';
 export { NodeFsProvider } from './providers/nodefs';
 export * from './types';

--- a/packages/code-provider/src/providers/local/index.ts
+++ b/packages/code-provider/src/providers/local/index.ts
@@ -1,213 +1,827 @@
-import { spawn, ChildProcess } from 'child_process';
-import { promises as fs } from 'fs';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import chokidar, { type FSWatcher } from 'chokidar';
+import { existsSync } from 'fs';
+import { promises as fs } from 'fs/promises';
+import net from 'net';
 import path from 'path';
-import { Provider, InitializeInput, InitializeOutput, StartProjectInput, StartProjectOutput, StopProjectInput, StopProjectOutput, DestroyInput, DestroyOutput, GetFileInput, GetFileOutput, WriteFileInput, WriteFileOutput, ListFilesInput, ListFilesOutput, InstallDependenciesInput, InstallDependenciesOutput, RunCommandInput, RunCommandOutput } from '../types';
+import { randomUUID } from 'crypto';
+import { once } from 'events';
+import { EventEmitter } from 'events';
+import {
+    Provider,
+    ProviderBackgroundCommand,
+    ProviderFileWatcher,
+    ProviderTask,
+    ProviderTerminal,
+    type CopyFileOutput,
+    type CopyFilesInput,
+    type CreateProjectInput,
+    type CreateProjectOutput,
+    type CreateSessionInput,
+    type CreateSessionOutput,
+    type CreateTerminalInput,
+    type CreateTerminalOutput,
+    type DeleteFilesInput,
+    type DeleteFilesOutput,
+    type DownloadFilesInput,
+    type DownloadFilesOutput,
+    type GetTaskInput,
+    type GetTaskOutput,
+    type GitStatusInput,
+    type GitStatusOutput,
+    type InitializeInput,
+    type InitializeOutput,
+    type ListFilesInput,
+    type ListFilesOutput,
+    type ListFilesOutputFile,
+    type ListProjectsInput,
+    type ListProjectsOutput,
+    type PauseProjectInput,
+    type PauseProjectOutput,
+    type ReadFileInput,
+    type ReadFileOutput,
+    type RenameFileInput,
+    type RenameFileOutput,
+    type SetupInput,
+    type SetupOutput,
+    type StatFileInput,
+    type StatFileOutput,
+    type StopProjectInput,
+    type StopProjectOutput,
+    type TerminalBackgroundCommandInput,
+    type TerminalBackgroundCommandOutput,
+    type TerminalCommandInput,
+    type TerminalCommandOutput,
+    type WatchEvent,
+    type WatchFilesInput,
+    type WatchFilesOutput,
+    type WriteFileInput,
+    type WriteFileOutput,
+} from '../../types';
+
+const DEFAULT_MAX_LOG_LINES = 200;
+const LOG_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+});
+
+type LogLevel = 'info' | 'warn' | 'error';
+
+export interface LocalSandboxLogEntry {
+    level: LogLevel;
+    message: string;
+    timestamp: Date;
+}
+
+export interface LocalProviderGetSession {
+    sandboxId: string;
+    port: number;
+    previewUrl: string;
+    projectPath: string;
+}
 
 export interface LocalProviderOptions {
-  projectPath: string;
-  port?: number;
+    sandboxId: string;
+    projectPath: string;
+    preferredPort?: number;
+    command?: {
+        bin: string;
+        args: string[];
+    };
+    projectsRoot?: string;
+    env?: Record<string, string>;
+    maxLogLines?: number;
+    getSession?: (sandboxId: string) => Promise<LocalProviderGetSession>;
+}
+
+export interface LocalCreateSessionOutput extends CreateSessionOutput {
+    sandboxId: string;
+    port: number;
+    previewUrl: string;
+    projectPath: string;
+}
+
+const DEFAULT_COMMAND = {
+    bin: 'bun',
+    args: ['run', 'dev'],
+};
+
+const DEFAULT_PREFERRED_PORT = 3000;
+
+function normalizeProjectPath(projectPath: string) {
+    return path.resolve(projectPath);
+}
+
+async function ensureDirectoryExists(dirPath: string) {
+    await fs.mkdir(dirPath, { recursive: true });
+}
+
+async function findAvailablePort(startPort: number, attempts = 20): Promise<number> {
+    let port = startPort;
+    for (let i = 0; i < attempts; i++) {
+        const available = await new Promise<boolean>((resolve) => {
+            const server = net.createServer();
+            server.once('error', () => {
+                server.close(() => resolve(false));
+            });
+            server.once('listening', () => {
+                server.close(() => resolve(true));
+            });
+            server.listen(port, '127.0.0.1');
+        });
+        if (available) {
+            return port;
+        }
+        port += 1;
+    }
+    return port;
+}
+
+function detectLogLevel(message: string, source: 'stdout' | 'stderr'): LogLevel {
+    if (source === 'stderr') {
+        return 'error';
+    }
+    const lower = message.toLowerCase();
+    if (lower.includes('error')) {
+        return 'error';
+    }
+    if (lower.includes('warn')) {
+        return 'warn';
+    }
+    return 'info';
+}
+
+function formatLogEntry(entry: LocalSandboxLogEntry): string {
+    const timestamp = LOG_TIMESTAMP_FORMATTER.format(entry.timestamp);
+    return `[${timestamp}] [${entry.level.toUpperCase()}] ${entry.message}`;
+}
+
+function toSandboxRelativePath(root: string, targetPath: string) {
+    const relative = path.relative(root, targetPath);
+    return relative === '' ? '.' : relative.replace(/\\/g, '/');
+}
+
+function buildListFilesOutput(dirents: ListFilesOutputFile[]): ListFilesOutput {
+    return { files: dirents };
+}
+
+function ensureCommand(options: LocalProviderOptions): { bin: string; args: string[] } {
+    if (options.command) {
+        return options.command;
+    }
+    return DEFAULT_COMMAND;
+}
+
+class LocalSandboxRuntime extends EventEmitter {
+    readonly sandboxId: string;
+    readonly projectPath: string;
+    readonly maxLogLines: number;
+    private preferredPort: number;
+    private process: ChildProcessWithoutNullStreams | null = null;
+    private startPromise: Promise<void> | null = null;
+    private stopPromise: Promise<void> | null = null;
+    private resolvedPort: number | null = null;
+    private readonly command: { bin: string; args: string[] };
+    private readonly env: Record<string, string>;
+    private readonly logBuffer: LocalSandboxLogEntry[] = [];
+
+    constructor(options: LocalProviderOptions) {
+        super();
+        this.sandboxId = options.sandboxId;
+        this.projectPath = normalizeProjectPath(options.projectPath);
+        this.preferredPort = options.preferredPort ?? DEFAULT_PREFERRED_PORT;
+        this.command = ensureCommand(options);
+        this.env = options.env ?? {};
+        this.maxLogLines = options.maxLogLines ?? DEFAULT_MAX_LOG_LINES;
+    }
+
+    get port(): number {
+        return this.resolvedPort ?? this.preferredPort;
+    }
+
+    get isRunning(): boolean {
+        return Boolean(this.process);
+    }
+
+    private appendLog(level: LogLevel, message: string) {
+        const logEntry: LocalSandboxLogEntry = {
+            level,
+            message,
+            timestamp: new Date(),
+        };
+        this.logBuffer.push(logEntry);
+        if (this.logBuffer.length > this.maxLogLines) {
+            this.logBuffer.splice(0, this.logBuffer.length - this.maxLogLines);
+        }
+        this.emit('log', logEntry);
+    }
+
+    async ensureStarted(): Promise<void> {
+        if (this.process) {
+            return;
+        }
+        if (this.startPromise) {
+            await this.startPromise;
+            return;
+        }
+        this.startPromise = this.spawnProcess();
+        try {
+            await this.startPromise;
+        } finally {
+            this.startPromise = null;
+        }
+    }
+
+    private async spawnProcess(): Promise<void> {
+        await ensureDirectoryExists(this.projectPath);
+        this.resolvedPort = await findAvailablePort(this.preferredPort);
+        const env = {
+            ...process.env,
+            ...this.env,
+            PORT: String(this.resolvedPort),
+            FORCE_COLOR: '1',
+        } as NodeJS.ProcessEnv;
+        this.appendLog('info', `Starting sandbox on port ${this.resolvedPort}`);
+        const child = spawn(this.command.bin, this.command.args, {
+            cwd: this.projectPath,
+            env,
+        });
+        this.process = child;
+
+        child.stdout?.on('data', (data: Buffer) => {
+            const content = data.toString();
+            content.split(/\r?\n/).filter(Boolean).forEach((line) => {
+                const level = detectLogLevel(line, 'stdout');
+                this.appendLog(level, line);
+            });
+        });
+
+        child.stderr?.on('data', (data: Buffer) => {
+            const content = data.toString();
+            content.split(/\r?\n/).filter(Boolean).forEach((line) => {
+                const level = detectLogLevel(line, 'stderr');
+                this.appendLog(level, line);
+            });
+        });
+
+        child.on('exit', (code, signal) => {
+            const reason = code !== null ? `code ${code}` : `signal ${signal}`;
+            this.appendLog('warn', `Sandbox exited with ${reason}`);
+            this.process = null;
+        });
+    }
+
+    async stop(): Promise<void> {
+        if (!this.process) {
+            return;
+        }
+        if (this.stopPromise) {
+            await this.stopPromise;
+            return;
+        }
+        this.stopPromise = new Promise<void>((resolve) => {
+            const child = this.process;
+            if (!child) {
+                resolve();
+                return;
+            }
+            const onExit = () => {
+                child.removeListener('exit', onExit);
+                this.process = null;
+                resolve();
+            };
+            child.once('exit', onExit);
+            child.kill('SIGTERM');
+            setTimeout(() => {
+                if (this.process) {
+                    this.appendLog('warn', 'Force killing sandbox process after timeout');
+                    child.kill('SIGKILL');
+                }
+            }, 5000);
+        });
+        try {
+            await this.stopPromise;
+        } finally {
+            this.stopPromise = null;
+        }
+    }
+
+    async restart(): Promise<void> {
+        await this.stop();
+        await this.ensureStarted();
+        this.appendLog('info', 'Sandbox restarted');
+    }
+
+    getLogs(level: LogLevel | 'all' = 'all'): LocalSandboxLogEntry[] {
+        if (level === 'all') {
+            return [...this.logBuffer];
+        }
+        return this.logBuffer.filter((entry) => entry.level === level);
+    }
+
+    onLog(listener: (entry: LocalSandboxLogEntry) => void, level: LogLevel | 'all' = 'all'): () => void {
+        const wrapped = (entry: LocalSandboxLogEntry) => {
+            if (level === 'all' || entry.level === level) {
+                listener(entry);
+            }
+        };
+        this.on('log', wrapped);
+        return () => {
+            this.off('log', wrapped);
+        };
+    }
+}
+
+class LocalRuntimeRegistry {
+    private static runtimes = new Map<string, LocalSandboxRuntime>();
+
+    static getOrCreate(options: LocalProviderOptions): LocalSandboxRuntime {
+        const existing = this.runtimes.get(options.sandboxId);
+        if (existing) {
+            return existing;
+        }
+        const runtime = new LocalSandboxRuntime(options);
+        this.runtimes.set(options.sandboxId, runtime);
+        return runtime;
+    }
+
+    static get(sandboxId: string): LocalSandboxRuntime | undefined {
+        return this.runtimes.get(sandboxId);
+    }
+
+    static remove(sandboxId: string): void {
+        this.runtimes.delete(sandboxId);
+    }
+}
+
+class LocalFileWatcher extends ProviderFileWatcher {
+    private watcher: FSWatcher | null = null;
+    private callback: ((event: WatchEvent) => Promise<void>) | null = null;
+
+    constructor(private readonly projectPath: string) {
+        super();
+    }
+
+    async start(input: WatchFilesInput): Promise<void> {
+        const { path: targetPath, recursive, excludes } = input.args;
+        const watchPath = path.resolve(this.projectPath, targetPath);
+        const ignored = excludes?.map((exclude) => path.resolve(this.projectPath, exclude)) ?? [];
+        this.watcher = chokidar.watch(watchPath, {
+            ignoreInitial: true,
+            persistent: true,
+            depth: recursive ? undefined : 0,
+            ignored,
+        });
+        this.watcher.on('all', async (event, filePath) => {
+            if (!this.callback) {
+                return;
+            }
+            const relative = toSandboxRelativePath(this.projectPath, filePath);
+            if (event === 'add' || event === 'addDir') {
+                await this.callback({ type: 'add', paths: [relative] });
+            } else if (event === 'change') {
+                await this.callback({ type: 'change', paths: [relative] });
+            } else if (event === 'unlink' || event === 'unlinkDir') {
+                await this.callback({ type: 'remove', paths: [relative] });
+            }
+        });
+    }
+
+    registerEventCallback(callback: (event: WatchEvent) => Promise<void>): void {
+        this.callback = callback;
+    }
+
+    async stop(): Promise<void> {
+        await this.watcher?.close();
+        this.watcher = null;
+        this.callback = null;
+    }
+}
+
+class LocalTerminal extends ProviderTerminal {
+    private readonly terminalId: string = randomUUID();
+    private readonly projectPath: string;
+    private process: ChildProcessWithoutNullStreams | null = null;
+    private listeners = new Set<(data: string) => void>();
+
+    constructor(projectPath: string) {
+        super();
+        this.projectPath = projectPath;
+    }
+
+    get id(): string {
+        return this.terminalId;
+    }
+
+    get name(): string {
+        return 'local-terminal';
+    }
+
+    private async ensureProcess(): Promise<ChildProcessWithoutNullStreams> {
+        if (this.process) {
+            return this.process;
+        }
+        const shell = process.env.SHELL || (process.platform === 'win32' ? 'powershell.exe' : 'bash');
+        const args = process.platform === 'win32' ? ['-NoLogo'] : ['-i'];
+        const child = spawn(shell, args, {
+            cwd: this.projectPath,
+            env: {
+                ...process.env,
+                FORCE_COLOR: '1',
+            },
+        });
+        this.process = child;
+        child.stdout?.on('data', (data: Buffer) => {
+            const message = data.toString();
+            this.listeners.forEach((listener) => listener(message));
+        });
+        child.stderr?.on('data', (data: Buffer) => {
+            const message = data.toString();
+            this.listeners.forEach((listener) => listener(message));
+        });
+        child.on('exit', () => {
+            this.process = null;
+        });
+        return child;
+    }
+
+    async open(): Promise<string> {
+        await this.ensureProcess();
+        return '';
+    }
+
+    async write(input: string): Promise<void> {
+        const proc = await this.ensureProcess();
+        proc.stdin?.write(input);
+    }
+
+    async run(input: string): Promise<void> {
+        const proc = await this.ensureProcess();
+        proc.stdin?.write(`${input}\n`);
+    }
+
+    async kill(): Promise<void> {
+        const proc = this.process;
+        if (!proc) {
+            return;
+        }
+        proc.kill('SIGTERM');
+        await once(proc, 'exit');
+        this.process = null;
+    }
+
+    onOutput(callback: (data: string) => void): () => void {
+        this.listeners.add(callback);
+        return () => {
+            this.listeners.delete(callback);
+        };
+    }
+}
+
+class LocalDevTask extends ProviderTask {
+    constructor(private readonly runtime: LocalSandboxRuntime) {
+        super();
+    }
+
+    get id(): string {
+        return 'dev';
+    }
+
+    get name(): string {
+        return 'Dev Server';
+    }
+
+    get command(): string {
+        return 'bun run dev';
+    }
+
+    async open(): Promise<string> {
+        const logs = this.runtime.getLogs('all');
+        return logs.map(formatLogEntry).join('\n');
+    }
+
+    async run(): Promise<void> {
+        await this.runtime.ensureStarted();
+    }
+
+    async restart(): Promise<void> {
+        await this.runtime.restart();
+    }
+
+    async stop(): Promise<void> {
+        await this.runtime.stop();
+    }
+
+    onOutput(callback: (data: string) => void): () => void {
+        return this.runtime.onLog((entry) => {
+            callback(formatLogEntry(entry));
+        });
+    }
+}
+
+class LocalBackgroundCommand extends ProviderBackgroundCommand {
+    constructor(private readonly runtime: LocalSandboxRuntime) {
+        super();
+    }
+
+    get name(): string | undefined {
+        return 'local-dev-server';
+    }
+
+    get command(): string {
+        return 'bun run dev';
+    }
+
+    async open(): Promise<string> {
+        return this.runtime.getLogs('all').map(formatLogEntry).join('\n');
+    }
+
+    async restart(): Promise<void> {
+        await this.runtime.restart();
+    }
+
+    async kill(): Promise<void> {
+        await this.runtime.stop();
+    }
+
+    onOutput(callback: (data: string) => void): () => void {
+        return this.runtime.onLog((entry) => callback(formatLogEntry(entry)));
+    }
+}
+
+function detectSandboxFileType(buffer: Buffer): 'binary' | 'text' {
+    const sample = buffer.subarray(0, Math.min(buffer.length, 512));
+    for (const byte of sample) {
+        if (byte === 0) {
+            return 'binary';
+        }
+    }
+    return 'text';
+}
+
+async function readSandboxFile(root: string, filePath: string) {
+    const absolute = path.resolve(root, filePath);
+    const data = await fs.readFile(absolute);
+    const type = detectSandboxFileType(data);
+    if (type === 'binary') {
+        return {
+            type: 'binary' as const,
+            path: filePath,
+            content: new Uint8Array(data),
+            toString: () => '',
+        };
+    }
+    const content = data.toString('utf8');
+    return {
+        type: 'text' as const,
+        path: filePath,
+        content,
+        toString: () => content,
+    };
 }
 
 export class LocalProvider extends Provider {
-  private projectPath: string;
-  private port: number;
-  private process: ChildProcess | null = null;
+    private readonly options: LocalProviderOptions;
+    private runtime: LocalSandboxRuntime;
 
-  constructor(options: LocalProviderOptions) {
-    super();
-    this.projectPath = options.projectPath;
-    this.port = options.port || 3000;
-  }
-
-  async initialize(input: InitializeInput): Promise<InitializeOutput> {
-    // Ensure project directory exists
-    await fs.mkdir(this.projectPath, { recursive: true });
-    return {};
-  }
-
-  async startProject(input: StartProjectInput): Promise<StartProjectOutput> {
-    try {
-      // Check if package.json exists
-      const packageJsonPath = path.join(this.projectPath, 'package.json');
-      const packageJsonExists = await fs.access(packageJsonPath).then(() => true).catch(() => false);
-
-      if (!packageJsonExists) {
-        // Create a basic package.json
-        const basicPackageJson = {
-          name: 'onlook-project',
-          version: '1.0.0',
-          scripts: {
-            dev: 'next dev',
-            build: 'next build',
-            start: 'next start'
-          },
-          dependencies: {
-            'next': '^14.0.0',
-            'react': '^18.0.0',
-            'react-dom': '^18.0.0'
-          }
+    constructor(options: LocalProviderOptions) {
+        super();
+        this.options = {
+            ...options,
+            projectPath: normalizeProjectPath(options.projectPath),
         };
-        await fs.writeFile(packageJsonPath, JSON.stringify(basicPackageJson, null, 2));
-      }
+        this.runtime = LocalRuntimeRegistry.getOrCreate(this.options);
+    }
 
-      // Start the development server
-      this.process = spawn('npm', ['run', 'dev'], {
-        cwd: this.projectPath,
-        stdio: 'pipe',
-        env: {
-          ...process.env,
-          PORT: this.port.toString()
+    private get projectPath() {
+        return this.options.projectPath;
+    }
+
+    async initialize(input: InitializeInput): Promise<InitializeOutput> {
+        await ensureDirectoryExists(this.projectPath);
+        if (this.options.getSession) {
+            const session = await this.options.getSession(this.options.sandboxId);
+            this.runtime = LocalRuntimeRegistry.getOrCreate({
+                ...this.options,
+                preferredPort: session.port,
+            });
+            await this.runtime.ensureStarted();
         }
-      });
-
-      // Wait a moment for the server to start
-      await new Promise(resolve => setTimeout(resolve, 3000));
-
-      return {
-        success: true,
-        url: `http://localhost:${this.port}`
-      };
-    } catch (error) {
-      console.error('Failed to start project:', error);
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Unknown error'
-      };
+        return {};
     }
-  }
 
-  async stopProject(input: StopProjectInput): Promise<StopProjectOutput> {
-    if (this.process) {
-      this.process.kill();
-      this.process = null;
-    }
-    return { success: true };
-  }
-
-  async destroy(input: DestroyInput): Promise<DestroyOutput> {
-    await this.stopProject({});
-    return { success: true };
-  }
-
-  async getFile(input: GetFileInput): Promise<GetFileOutput> {
-    try {
-      const filePath = path.join(this.projectPath, input.path);
-      const content = await fs.readFile(filePath, 'utf-8');
-      return {
-        success: true,
-        content
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'File not found'
-      };
-    }
-  }
-
-  async writeFile(input: WriteFileInput): Promise<WriteFileOutput> {
-    try {
-      const filePath = path.join(this.projectPath, input.path);
-      const dir = path.dirname(filePath);
-      await fs.mkdir(dir, { recursive: true });
-      await fs.writeFile(filePath, input.content, 'utf-8');
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to write file'
-      };
-    }
-  }
-
-  async listFiles(input: ListFilesInput): Promise<ListFilesOutput> {
-    try {
-      const dirPath = path.join(this.projectPath, input.path || '');
-      const entries = await fs.readdir(dirPath, { withFileTypes: true });
-      const files: string[] = [];
-
-      for (const entry of entries) {
-        const relativePath = path.join(input.path || '', entry.name);
-        if (entry.isDirectory()) {
-          const subFiles = await this.listFiles({ path: relativePath });
-          if (subFiles.success) {
-            files.push(...subFiles.files);
-          }
+    async writeFile(input: WriteFileInput): Promise<WriteFileOutput> {
+        const { path: targetPath, content } = input.args;
+        const absolute = path.resolve(this.projectPath, targetPath);
+        await ensureDirectoryExists(path.dirname(absolute));
+        if (typeof content === 'string') {
+            await fs.writeFile(absolute, content, 'utf8');
         } else {
-          files.push(relativePath);
+            await fs.writeFile(absolute, Buffer.from(content));
         }
-      }
-
-      return {
-        success: true,
-        files
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to list files',
-        files: []
-      };
+        return { success: true };
     }
-  }
 
-  async installDependencies(input: InstallDependenciesInput): Promise<InstallDependenciesOutput> {
-    try {
-      const process = spawn('npm', ['install'], {
-        cwd: this.projectPath,
-        stdio: 'pipe'
-      });
+    async renameFile(input: RenameFileInput): Promise<RenameFileOutput> {
+        const absoluteOld = path.resolve(this.projectPath, input.args.oldPath);
+        const absoluteNew = path.resolve(this.projectPath, input.args.newPath);
+        await ensureDirectoryExists(path.dirname(absoluteNew));
+        await fs.rename(absoluteOld, absoluteNew);
+        return {};
+    }
 
-      return new Promise((resolve) => {
-        process.on('close', (code) => {
-          resolve({
-            success: code === 0,
-            error: code !== 0 ? 'Failed to install dependencies' : undefined
-          });
+    async statFile(input: StatFileInput): Promise<StatFileOutput> {
+        const absolute = path.resolve(this.projectPath, input.args.path);
+        const stats = await fs.stat(absolute);
+        return {
+            type: stats.isDirectory() ? 'directory' : 'file',
+            size: stats.size,
+            mtime: stats.mtimeMs,
+            ctime: stats.ctimeMs,
+            atime: stats.atimeMs,
+        };
+    }
+
+    async deleteFiles(input: DeleteFilesInput): Promise<DeleteFilesOutput> {
+        const absolute = path.resolve(this.projectPath, input.args.path);
+        const recursive = input.args.recursive ?? false;
+        await fs.rm(absolute, { recursive, force: true });
+        return {};
+    }
+
+    async listFiles(input: ListFilesInput): Promise<ListFilesOutput> {
+        const absolute = path.resolve(this.projectPath, input.args.path);
+        const dirents = await fs.readdir(absolute, { withFileTypes: true });
+        const files: ListFilesOutputFile[] = dirents.map((dirent) => ({
+            name: dirent.name,
+            type: dirent.isDirectory() ? 'directory' : 'file',
+            isSymlink: dirent.isSymbolicLink(),
+        }));
+        return buildListFilesOutput(files);
+    }
+
+    async readFile(input: ReadFileInput): Promise<ReadFileOutput> {
+        const file = await readSandboxFile(this.projectPath, input.args.path);
+        return { file };
+    }
+
+    async downloadFiles(input: DownloadFilesInput): Promise<DownloadFilesOutput> {
+        return { url: undefined };
+    }
+
+    async copyFiles(input: CopyFilesInput): Promise<CopyFileOutput> {
+        const source = path.resolve(this.projectPath, input.args.sourcePath);
+        const target = path.resolve(this.projectPath, input.args.targetPath);
+        await ensureDirectoryExists(path.dirname(target));
+        await fs.cp(source, target, { recursive: input.args.recursive ?? false, force: input.args.overwrite ?? false });
+        return {};
+    }
+
+    async watchFiles(input: WatchFilesInput): Promise<WatchFilesOutput> {
+        const watcher = new LocalFileWatcher(this.projectPath);
+        await watcher.start(input);
+        return { watcher };
+    }
+
+    async createTerminal(input: CreateTerminalInput): Promise<CreateTerminalOutput> {
+        const terminal = new LocalTerminal(this.projectPath);
+        await terminal.open();
+        return { terminal };
+    }
+
+    async getTask(input: GetTaskInput): Promise<GetTaskOutput> {
+        if (input.args.id !== 'dev') {
+            throw new Error(`Unsupported task id: ${input.args.id}`);
+        }
+        await this.runtime.ensureStarted();
+        return { task: new LocalDevTask(this.runtime) };
+    }
+
+    async runCommand(input: TerminalCommandInput): Promise<TerminalCommandOutput> {
+        const command = input.args.command;
+        const child = spawn(command, {
+            cwd: this.projectPath,
+            shell: true,
         });
-      });
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to install dependencies'
-      };
-    }
-  }
-
-  async runCommand(input: RunCommandInput): Promise<RunCommandOutput> {
-    try {
-      const [command, ...args] = input.command.split(' ');
-      const process = spawn(command, args, {
-        cwd: this.projectPath,
-        stdio: 'pipe'
-      });
-
-      let output = '';
-      let error = '';
-
-      process.stdout?.on('data', (data) => {
-        output += data.toString();
-      });
-
-      process.stderr?.on('data', (data) => {
-        error += data.toString();
-      });
-
-      return new Promise((resolve) => {
-        process.on('close', (code) => {
-          resolve({
-            success: code === 0,
-            output,
-            error: code !== 0 ? error : undefined
-          });
+        let output = '';
+        let error = '';
+        child.stdout?.on('data', (data: Buffer) => {
+            output += data.toString();
         });
-      });
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to run command',
-        output: ''
-      };
+        child.stderr?.on('data', (data: Buffer) => {
+            error += data.toString();
+        });
+        const exitCode: number = await new Promise((resolve) => {
+            child.on('close', (code) => resolve(code ?? 0));
+        });
+        if (exitCode !== 0) {
+            return { output, error };
+        }
+        return { output };
     }
-  }
+
+    async runBackgroundCommand(
+        input: TerminalBackgroundCommandInput,
+    ): Promise<TerminalBackgroundCommandOutput> {
+        return { command: new LocalBackgroundCommand(this.runtime) };
+    }
+
+    async gitStatus(input: GitStatusInput): Promise<GitStatusOutput> {
+        const child = spawn('git', ['status', '--porcelain'], {
+            cwd: this.projectPath,
+        });
+        const chunks: string[] = [];
+        child.stdout?.on('data', (data: Buffer) => {
+            chunks.push(data.toString());
+        });
+        await once(child, 'close');
+        const output = chunks.join('');
+        const changedFiles = output
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean);
+        return { changedFiles };
+    }
+
+    async setup(input: SetupInput): Promise<SetupOutput> {
+        return {};
+    }
+
+    async createSession(input: CreateSessionInput): Promise<LocalCreateSessionOutput> {
+        await this.runtime.ensureStarted();
+        return {
+            sandboxId: this.options.sandboxId,
+            port: this.runtime.port,
+            previewUrl: `http://localhost:${this.runtime.port}`,
+            projectPath: this.projectPath,
+        };
+    }
+
+    async reload(): Promise<boolean> {
+        await this.runtime.restart();
+        return true;
+    }
+
+    async reconnect(): Promise<void> {
+        await this.runtime.ensureStarted();
+    }
+
+    async ping(): Promise<boolean> {
+        return this.runtime.isRunning;
+    }
+
+    static async createProject(input: CreateProjectInput): Promise<CreateProjectOutput> {
+        const projectPath = path.resolve('./onlook-projects', input.id);
+        await ensureDirectoryExists(projectPath);
+        return { id: input.id };
+    }
+
+    static async createProjectFromGit(input: { repoUrl: string; branch: string; }): Promise<CreateProjectOutput> {
+        throw new Error('createProjectFromGit is not implemented for LocalProvider');
+    }
+
+    async pauseProject(input: PauseProjectInput): Promise<PauseProjectOutput> {
+        await this.runtime.stop();
+        return {};
+    }
+
+    async stopProject(input: StopProjectInput): Promise<StopProjectOutput> {
+        await this.runtime.stop();
+        LocalRuntimeRegistry.remove(this.options.sandboxId);
+        return {};
+    }
+
+    async listProjects(input: ListProjectsInput): Promise<ListProjectsOutput> {
+        const projectsRoot = this.options.projectsRoot ?? path.resolve(this.projectPath, '..');
+        if (!existsSync(projectsRoot)) {
+            return {} as ListProjectsOutput;
+        }
+        const entries = await fs.readdir(projectsRoot, { withFileTypes: true });
+        const projects = entries
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => ({
+                id: entry.name,
+                path: path.join(projectsRoot, entry.name),
+            }));
+        return { projects } as unknown as ListProjectsOutput;
+    }
+
+    async destroy(): Promise<void> {
+        // keep runtime alive for preview; explicit stop handled elsewhere
+    }
+
+    getDevServerLogs(level: LogLevel | 'all' = 'all'): LocalSandboxLogEntry[] {
+        return this.runtime.getLogs(level);
+    }
+
+    subscribeToDevServerLogs(
+        callback: (entry: LocalSandboxLogEntry) => void,
+        level: LogLevel | 'all' = 'all',
+    ): () => void {
+        return this.runtime.onLog(callback, level);
+    }
 }
+
+export type { LogLevel as LocalSandboxLogLevel };


### PR DESCRIPTION
## Summary
- replace the local code provider with a Bun-backed runtime that auto-selects ports, keeps a bounded log buffer, and exposes restart/read APIs
- switch the sandbox API/router and session manager to detect local sandboxes, hydrate the new provider, and surface structured logs and subscriptions
- add a sandbox logs panel alongside the terminal UI and document the local sandbox bootstrap flow in docs/sandbox-local.md

## Testing
- `bun run --cwd apps/web/client typecheck` *(fails: repository currently lacks the React/JSX type configuration in multiple landing page components)*

------
https://chatgpt.com/codex/tasks/task_e_68d40beeb34c832cb15340eb587a63e7